### PR TITLE
(DNM) Port sharded repodata logic from conda-libmamba-solver

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,7 @@ env:
   # we can't break classic from here; no need to test it
   # those tests will still be available for local debugging if necessary
   CONDA_TEST_SOLVERS: rattler
+  CONDA_PLUGINS_USE_SHARDED_REPODATA: "1"
 
 jobs:
   # detect whether any code changes are included in this PR

--- a/conda_rattler_solver/index.py
+++ b/conda_rattler_solver/index.py
@@ -138,7 +138,7 @@ class RattlerIndexHelper:
             key = split_anaconda_token(remove_auth(key))[0]
         return self._index[key]
 
-    def _fetch_channel(self, url: str) -> tuple[str, os.PathLike]:
+    def _fetch_channel(self, url: str) -> tuple[str, os.PathLike, RepodataState]:
         channel = Channel.from_url(url)
         if not channel.subdir:
             raise ValueError(f"Channel URLs must specify a subdir! Provided: {url}")
@@ -153,9 +153,9 @@ class RattlerIndexHelper:
 
         log.debug("Fetching %s with SubdirData.repo_fetch", channel)
         subdir_data = SubdirData(channel, repodata_fn=self._repodata_fn)
-        json_path, _ = subdir_data.repo_fetch.fetch_latest_path()
+        json_path, state = subdir_data.repo_fetch.fetch_latest_path()
 
-        return url, json_path
+        return url, json_path, state
 
     def _json_path_to_repo_info(self, url: str, json_path: str) -> _ChannelRepoInfo:
         channel = Channel.from_url(url)
@@ -175,7 +175,7 @@ class RattlerIndexHelper:
             self._unlink_on_del.append(path_copy)
         # TODO: Support multichannel https://github.com/conda/rattler/issues/1327
         rattler_channel = rattler.Channel(noauth_url_sans_subdir)
-        repo = rattler.SparseRepoData(rattler_channel, channel.subdir, json_path)
+        repo = rattler.SparseRepoData(rattler_channel, channel.subdir or "noarch", json_path)
         return _ChannelRepoInfo(
             repo=repo,
             channel=channel,
@@ -230,7 +230,7 @@ class RattlerIndexHelper:
         with Executor() as executor:
             return {
                 url: (str(path), state)
-                for (url, path, state) in executor.map(self._fetch_one_repodata_json, urls)
+                for (url, path, state) in executor.map(self._fetch_channel, urls)
             }
 
     @staticmethod
@@ -303,24 +303,8 @@ class RattlerIndexHelper:
         urls_to_json_path_and_state = self._fetch_repodata_jsons(tuple(urls_to_channel.keys()))
 
         channel_repo_infos = []
-        for url_w_cred, (json_path, state) in urls_to_json_path_and_state.items():
-            url_no_token, _ = split_anaconda_token(url_w_cred)
-            url_no_cred = remove_auth(url_no_token)
-            repo = self._json_path_to_repo_info(
-                json_path,
-                url_no_cred,
-                state,
-                try_solv=(try_solv and not self._in_state),
-            )
-            channel_repo_infos.append(
-                _ChannelRepoInfo(
-                    channel=urls_to_channel[url_w_cred],
-                    repo=repo,
-                    url_w_cred=url_w_cred,
-                    url_no_cred=url_no_cred,
-                )
-            )
-
+        for url_w_cred, (json_path, _) in urls_to_json_path_and_state.items():
+            channel_repo_infos.append(self._json_path_to_repo_info(url_w_cred, json_path))
         return channel_repo_infos
 
     @staticmethod

--- a/conda_rattler_solver/index.py
+++ b/conda_rattler_solver/index.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 import rattler
 from conda.base.constants import REPODATA_FN
 from conda.base.context import context
-from conda.common.io import DummyExecutor, ThreadLimitedThreadPoolExecutor
+from conda.common.io import DummyExecutor, ThreadLimitedThreadPoolExecutor, time_recorder
 from conda.common.url import path_to_url, remove_auth, split_anaconda_token
 from conda.core.package_cache_data import PackageCacheData
 from conda.core.subdir_data import SubdirData
@@ -26,15 +26,20 @@ try:
 except ImportError:
     from conda.common.serialize import json_dump
 
+from .shards_subset import build_repodata_subset
 from .utils import empty_repodata_dict, rattler_record_to_conda_record
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
     from typing import Self
 
     from conda.common.path import PathsType
+    from conda.gateways.repodata import RepodataState
     from conda.models.match_spec import MatchSpec
     from conda.models.records import PackageCacheRecord, PackageRecord
+
+    from .shards import ShardBase
+    from .state import SolverInputState
 
 log = logging.getLogger(f"conda.{__name__}")
 
@@ -50,6 +55,14 @@ class _ChannelRepoInfo:
     local_json: str | None
 
 
+def _is_sharded_repodata_enabled() -> bool:
+    """
+    Flag to see whether we should check for sharded repodata.
+    """
+    # NOTE: We may need to turn this into a conda setting, not just conda-libmamba-solver's
+    return context.plugins.use_sharded_repodata is True
+
+
 class RattlerIndexHelper:
     def __init__(
         self,
@@ -57,15 +70,18 @@ class RattlerIndexHelper:
         subdirs: Iterable[str] = None,
         repodata_fn: str = REPODATA_FN,
         pkgs_dirs: PathsType = (),
+        in_state: SolverInputState | None = None,
     ):
         self._unlink_on_del: list[Path] = []
 
         self._channels = context.channels if channels is None else channels
         self._subdirs = context.subdirs if subdirs is None else subdirs
         self._repodata_fn = repodata_fn
+        self._in_state = in_state
 
-        self._index: dict[str, _ChannelRepoInfo] = {}
-        self._index.update(self._load_channels())
+        self._index: dict[str, _ChannelRepoInfo] = {
+            info.noauth_url: info for info in self._load_channels()
+        }
         if pkgs_dirs:
             self._index.update(
                 {info.noauth_url: info for info in self._load_pkgs_cache(pkgs_dirs)}
@@ -101,7 +117,7 @@ class RattlerIndexHelper:
     def n_packages(
         self,
         repos: Iterable[_ChannelRepoInfo] | None = None,
-        filter_: callable | None = None,
+        filter_: Callable | None = None,
     ) -> int:
         count = 0
         if filter_ is not None:
@@ -168,17 +184,168 @@ class RattlerIndexHelper:
             local_json=json_path,
         )
 
-    def _urls_from_channels(self, channels: Iterable[Channel | str] | None = None) -> tuple[str]:
-        # 1. Obtain and deduplicate URLs from channels
-        urls = []
+    def _channel_to_id(self, channel: Channel):
+        channel_id = channel.canonical_name
+        if channel_id in context.custom_multichannels:
+            # In multichannels, the canonical name of a "subchannel" is the multichannel name
+            # which makes it ambiguous for `channel::specs`. In those cases, take the channel
+            # regular name; e.g. for repo.anaconda.com/pkgs/main, do not take defaults, but
+            # pkgs/main instead.
+            channel_id = channel.name
+        return channel_id
+
+    def _load_channels(
+        self,
+        urls_to_channel: dict[str, Channel] | None = None,
+        try_solv: bool = True,
+    ) -> list[_ChannelRepoInfo]:
+        if urls_to_channel is None:
+            urls_to_channel = self._channel_urls(self._subdirs, self._channels)
+
+        urls_to_channel = self._encoded_urls_to_channels(urls_to_channel)
+
+        # Prefer sharded repodata loading if it's enabled
+        if self._in_state is not None and _is_sharded_repodata_enabled():
+            # TODO: It may be better to directly pass channel objects without URL encoding
+
+            # Channels are not loaded in order from shards. Once we load the shards,
+            # reorder the list to match the intended channel order. If the channel
+            # is not in the urls_to_channel, we'll add it to the back
+            channel_repos_info = self._load_channel_repo_info_shards(urls_to_channel)
+            urls_to_channel_as_list = list(urls_to_channel.keys())
+            return sorted(
+                channel_repos_info,
+                key=lambda x: urls_to_channel_as_list.index(x.channel) or 0,
+            )
+
+        # Fallback to repodata.json loading
+        return self._load_channel_repo_info_json(urls_to_channel, try_solv)
+
+    def _fetch_repodata_jsons(self, urls: Iterable[str]) -> dict[str, tuple[str, RepodataState]]:
+        Executor = (
+            DummyExecutor
+            if context.debug or context.repodata_threads == 1
+            else partial(ThreadLimitedThreadPoolExecutor, max_workers=context.repodata_threads)
+        )
+        with Executor() as executor:
+            return {
+                url: (str(path), state)
+                for (url, path, state) in executor.map(self._fetch_one_repodata_json, urls)
+            }
+
+    @staticmethod
+    def _encoded_urls_to_channels(urls_to_channel: dict[str, Channel]) -> dict[str, Channel]:
+        """
+        Return copy of urls_to_channel with %-encoded spaces.
+
+        Usage: _encoded_urls_to_channels(_channel_urls(subdirs, channels))
+        """
+        # conda.common.url.path_to_url does not %-encode spaces
+        encoded_urls_to_channel: dict[str, Channel] = {}
+        for url, channel in urls_to_channel.items():
+            if url.startswith("file://"):
+                url = url.replace(" ", "%20")
+            encoded_urls_to_channel[url] = channel
+        return encoded_urls_to_channel
+
+    def _load_channel_repo_info_shards(
+        self, urls_to_channel: dict[str, Channel]
+    ) -> list[_ChannelRepoInfo]:
+        """
+        Load repository information from sharded repodata cache.
+        """
+        # make a subset of possible dependencies
+        root_packages = (*self._in_state.installed.keys(), *self._in_state.requested)
+        channel_data = build_repodata_subset(root_packages, urls_to_channel)
+        channel_repo_infos = self._load_channel_repo_info_shards_inner(channel_data)
+
+        return channel_repo_infos
+
+    @time_recorder(module_name=__name__)
+    def _load_channel_repo_info_shards_inner(
+        self, repodata_subset: dict[str, ShardBase]
+    ) -> list[_ChannelRepoInfo]:
+        """
+        Load repository information from deserialized repodata.json-like
+        structures.
+
+        NOTE: This function initially converted all the raw repodata entries
+        to libmamba PackageInfo objects. rattler does not support loading from its
+        objects so we go through JSON on disk.
+        """
+        repos = []
+        for channel_url, shardlike in repodata_subset.items():
+            repodata = shardlike.build_repodata()
+            repodata_tmp = NamedTemporaryFile(suffix=".json", delete=False)
+            repodata_path = Path(repodata_tmp.name)
+            self._unlink_on_del.append(repodata_path)
+            repodata_path.write_text(json_dump(repodata, sort_keys=True))
+            repos.append(self._json_path_to_repo_info(channel_url, repodata_tmp.name))
+
+        return repos
+
+    def _channel_to_id(self, channel: Channel):
+        channel_id = channel.canonical_name
+        if channel_id in context.custom_multichannels:
+            # In multichannels, the canonical name of a "subchannel" is the multichannel name
+            # which makes it ambiguous for `channel::specs`. In those cases, take the channel
+            # regular name; e.g. for repo.anaconda.com/pkgs/main, do not take defaults, but
+            # pkgs/main instead.
+            channel_id = channel.name
+        return channel_id
+
+    def _load_channel_repo_info_json(
+        self, urls_to_channel: dict[str, Channel], try_solv: bool
+    ) -> list[_ChannelRepoInfo]:
+        """
+        Load repository information from repodata.json files.
+        """
+        urls_to_json_path_and_state = self._fetch_repodata_jsons(tuple(urls_to_channel.keys()))
+
+        channel_repo_infos = []
+        for url_w_cred, (json_path, state) in urls_to_json_path_and_state.items():
+            url_no_token, _ = split_anaconda_token(url_w_cred)
+            url_no_cred = remove_auth(url_no_token)
+            repo = self._json_path_to_repo_info(
+                json_path,
+                url_no_cred,
+                state,
+                try_solv=(try_solv and not self._in_state),
+            )
+            channel_repo_infos.append(
+                _ChannelRepoInfo(
+                    channel=urls_to_channel[url_w_cred],
+                    repo=repo,
+                    url_w_cred=url_w_cred,
+                    url_no_cred=url_no_cred,
+                )
+            )
+
+        return channel_repo_infos
+
+    @staticmethod
+    def _channel_urls(subdirs: Iterable[str], channels: list[Channel]) -> dict[str, Channel]:
+        "Map authenticated URLs to channel objects."
+        # class method for testing etc.
+        urls = {}
         seen_noauth = set()
-        for _c in channels or self._channels:
-            c = Channel(_c)
-            noauth_urls = c.urls(with_credentials=False, subdirs=self._subdirs)
+        channels_with_subdirs = []
+        for channel in channels:
+            for url in channel.urls(with_credentials=True, subdirs=subdirs):
+                channels_with_subdirs.append(Channel(url))
+        for channel in channels_with_subdirs:
+            noauth_urls = [
+                url for url in channel.urls(with_credentials=False) if url.endswith(channel.subdir)
+            ]
             if seen_noauth.issuperset(noauth_urls):
                 continue
-            if c.auth or c.token:  # authed channel always takes precedence
-                urls += Channel(c).urls(with_credentials=True, subdirs=self._subdirs)
+            auth_urls = [
+                url.replace(" ", "%20")
+                for url in channel.urls(with_credentials=True)
+                if url.endswith(tuple(subdirs))
+            ]
+            if noauth_urls != auth_urls:  # authed channel always takes precedence
+                urls.update({url: channel for url in auth_urls})
                 seen_noauth.update(noauth_urls)
                 continue
             # at this point, we are handling an unauthed channel; in some edge cases,
@@ -186,31 +353,9 @@ class RattlerIndexHelper:
             # we only add them if we haven't seen them yet
             for url in noauth_urls:
                 if url not in seen_noauth:
-                    urls.append(url)
+                    urls[url] = channel
                     seen_noauth.add(url)
-
-        return tuple(dict.fromkeys(urls))  # de-duplicate
-
-    def _load_channels(self, urls: Iterable[str] | None = None) -> dict[str, _ChannelRepoInfo]:
-        if urls is None:
-            urls = self._urls_from_channels()
-
-        # 1. Fetch URLs (if needed)
-        Executor = (
-            DummyExecutor
-            if context.debug or context.repodata_threads == 1
-            else partial(ThreadLimitedThreadPoolExecutor, max_workers=context.repodata_threads)
-        )
-        with Executor() as executor:
-            jsons = {url: str(path) for (url, path) in executor.map(self._fetch_channel, urls)}
-
-        # 2. Create repos in same order as `urls`
-        index = {}
-        for url in urls:
-            info = self._json_path_to_repo_info(url, jsons[url])
-            index[info.noauth_url] = info
-
-        return index
+        return urls
 
     def _load_pkgs_cache(self, pkgs_dirs: PathsType) -> list[_ChannelRepoInfo]:
         repos = []

--- a/conda_rattler_solver/shards.py
+++ b/conda_rattler_solver/shards.py
@@ -1,0 +1,729 @@
+# Copyright (C) 2022 Anaconda, Inc
+# Copyright (C) 2023 conda
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Models for sharded repodata, and to make monolithic repodata look like sharded
+repodata.
+"""
+
+from __future__ import annotations
+
+import abc
+import concurrent.futures
+import functools
+import json
+import logging
+from collections import defaultdict
+from pathlib import Path
+from typing import TYPE_CHECKING
+from urllib.parse import urljoin
+
+import conda.exceptions
+import conda.gateways.repodata
+import msgpack
+import zstandard
+from conda.base.context import context
+from conda.core.subdir_data import SubdirData
+from conda.gateways.connection.session import get_session
+from conda.gateways.repodata import (
+    _add_http_value_to_dict,
+    conda_http_errors,
+)
+from conda.models.channel import Channel
+from libmambapy.bindings import specs
+
+from . import shards_cache
+
+log = logging.getLogger(__name__)
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, KeysView
+
+    from conda.gateways.repodata import RepodataCache
+    from requests import Response
+
+    from conda_libmamba_solver.shards_typing import RepodataDict, ShardsIndexDict
+
+    from .shards_typing import PackageRecordDict, ShardDict
+
+SHARDS_CONNECTIONS_DEFAULT = 10
+ZSTD_MAX_SHARD_SIZE = 2**20 * 16  # maximum size necessary when compressed data has no size header
+# For reference, the largest shard "conda-forge/linux-64/vim" is 2608283 bytes
+# or < 2**19*5 decompressed (486155 bytes compressed); the index is 575219 bytes
+# decompressed (514039 bytes compressed) and is mostly uncompressible hash data.
+
+
+def _shards_connections() -> int:
+    """
+    If context.repodata_threads is not set, find the size of the connection pool
+    in a typical https:// session. This should significantly reduce dropped
+    connections. We match requests' default 10.
+
+    Is this shared between all sessions? Or do we get a different pool for a
+    different get_session(url)?
+
+    Other adapters (file://, s3://) used in conda would have different
+    concurrency behavior;  we are not prepared to have separate threadpools per
+    connection type.
+    """
+    if context.repodata_threads is not None:
+        return context.repodata_threads
+    return SHARDS_CONNECTIONS_DEFAULT
+
+
+def ensure_hex_hash(record: PackageRecordDict):
+    """
+    Convert bytes checksums to hex; leave unchanged if already str.
+    """
+    for hash_type in "sha256", "md5":
+        if hash_value := record.get(hash_type):
+            if not isinstance(hash_value, str):
+                record[hash_type] = bytes(hash_value).hex()
+    return record
+
+
+@functools.cache
+def spec_to_package_name(spec: str) -> str:
+    """
+    Given a dependency spec, return the package name.
+    """
+    # Note: hope for no MatchSpec-without-name in repodata, although it is
+    # possible in the MatchSpec grammar.
+    parsed_spec = specs.MatchSpec.parse(spec)
+    name = str(parsed_spec.name)
+    return name
+
+
+def shard_mentioned_packages(shard: ShardDict) -> Iterable[str]:
+    """
+    Return all dependency names mentioned in a shard, not including the shard's
+    own package name.
+    """
+    unique_specs = set()
+    for package in (*shard["packages"].values(), *shard["packages.conda"].values()):
+        ensure_hex_hash(package)  # otherwise we could do this at serialization
+        for spec in (*package.get("depends", ()),):  # , *package.get("constrains", ())):
+            if spec in unique_specs:
+                continue
+            unique_specs.add(spec)
+            name = spec_to_package_name(spec)
+            yield name  # not much improvement from only yielding unique names
+
+
+class ShardBase(abc.ABC):
+    """
+    Abstract base class for shard-like objects.
+
+    Defines the common interface for both sharded repodata (Shards)
+    and traditional repodata presented as shards (ShardLike).
+    """
+
+    url: str
+    repodata_no_packages: RepodataDict
+    visited: dict[str, ShardDict | None]
+    _base_url: str
+
+    @property
+    @abc.abstractmethod
+    def package_names(self) -> KeysView[str]:
+        """Return the names of all packages available in this shard collection."""
+        ...
+
+    @property
+    def base_url(self) -> str:
+        """
+        Return self.url joined with base_url from repodata, or self.url if no
+        base_url was present. Packages are found here.
+
+        Note base_url can be a relative or an absolute url.
+        The double urljoin ensures proper URL normalization:
+        first join with _base_url, then with "." to add trailing slash
+        if needed.
+        """
+        return urljoin(urljoin(self.url, self._base_url), ".")
+
+    def __contains__(self, package: str) -> bool:
+        """Check if a package is available in this shard collection."""
+        return package in self.package_names
+
+    @abc.abstractmethod
+    def shard_url(self, package: str) -> str:
+        """
+        Return shard URL for a given package. For monolithic repodata, should
+        not be fetched but is a unique identifier.
+
+        Raise KeyError if package is not in the index.
+        """
+        ...
+
+    @abc.abstractmethod
+    def shard_loaded(self, package: str) -> bool:
+        """
+        Return True if the given package's shard is in memory.
+        """
+        ...
+
+    def visit_package(self, package: str) -> ShardDict:
+        """
+        Return a shard that is already loaded in memory and mark as visited.
+        """
+        ...
+
+    def visit_shard(self, package: str, shard: ShardDict):
+        """
+        Store new shard data in the visited dict.
+        """
+        self.visited[package] = shard
+
+    @abc.abstractmethod
+    def fetch_shard(self, package: str) -> ShardDict:
+        """
+        Fetch an individual shard for the given package.
+        """
+        ...
+
+    @abc.abstractmethod
+    def fetch_shards(self, packages: Iterable[str]) -> dict[str, ShardDict]:
+        """
+        Fetch multiple shards in one go.
+        """
+        ...
+
+    def build_repodata(self) -> RepodataDict:
+        """
+        Return monolithic repodata including all visited shards.
+        """
+        repodata = self.repodata_no_packages.copy()
+        repodata.update({"packages": {}, "packages.conda": {}})
+        for _, shard in self.visited.items():
+            if shard is None:
+                continue  # recorded visited but not available shards
+            for package_group in ("packages", "packages.conda"):
+                repodata[package_group].update(shard[package_group])
+        return repodata
+
+
+class ShardLike(ShardBase):
+    """
+    Present a "classic" repodata.json as per-package shards.
+    """
+
+    def __init__(self, repodata: RepodataDict, url: str = ""):
+        """
+        url: must be unique for all ShardLike used together.
+        """
+        self.repodata_no_packages: RepodataDict = {
+            **repodata,
+            "packages": {},
+            "packages.conda": {},
+        }
+        all_packages = {
+            "packages": repodata.get("packages", {}),
+            "packages.conda": repodata.get("packages.conda", {}),
+        }
+        self.url = url
+
+        shards = defaultdict(lambda: {"packages": {}, "packages.conda": {}})
+
+        for group_name, group in all_packages.items():
+            for package, record in group.items():
+                name = record["name"]
+                shards[name][group_name][package] = record
+
+        # defaultdict behavior no longer wanted
+        self.shards: dict[str, ShardDict] = dict(shards)  # type: ignore
+
+        # used to write out repodata subset
+        self.visited: dict[str, ShardDict | None] = {}
+
+        # alternate location for packages, if not self.url
+        try:
+            base_url = self.repodata_no_packages["info"]["base_url"]
+            if not isinstance(base_url, str):
+                log.warning(f'repodata["info"]["base_url"] was not a str, got {type(base_url)}')
+                raise TypeError()
+            self._base_url = base_url
+        except KeyError:
+            self._base_url = ""
+
+    def __repr__(self):
+        left, right = super().__repr__().split(maxsplit=1)
+        return f"{left} {self.url} {right}"
+
+    @property
+    def package_names(self) -> KeysView[str]:
+        return self.shards.keys()
+
+    def shard_url(self, package: str) -> str:
+        """
+        Return shard URL for a given package.
+
+        Raise KeyError if package is not in the index.
+        """
+        self.shards[package]
+        return f"{self.url}#{package}"
+
+    def shard_loaded(self, package: str) -> bool:
+        """
+        Return True if the given package's shard is in memory.
+        """
+        return package in self.shards
+
+    def visit_package(self, package: str) -> ShardDict:
+        """
+        Return a shard that is already in memory and mark as visited.
+        """
+        shard = self.fetch_shard(package)
+        assert shard is not None
+        return shard
+
+    def fetch_shard(self, package: str) -> ShardDict:
+        """
+        "Fetch" an individual shard.
+
+        Update self.visited with all not-None packages.
+
+        Raise KeyError if package is not in the index.
+        """
+        shard = self.shards[package]
+        self.visited[package] = shard
+        return shard
+
+    def fetch_shards(self, packages: Iterable[str]) -> dict[str, ShardDict]:
+        """
+        Fetch multiple shards in one go.
+
+        Update self.visited with all not-None packages.
+        """
+        return {package: self.fetch_shard(package) for package in packages}
+
+
+def _shards_base_url(url, shards_base_url) -> str:
+    """
+    Return shards_base_url joined with base_url and url.
+    Note shards_base_url can be a relative or an absolute url.
+    """
+    if shards_base_url and not shards_base_url.endswith("/"):
+        shards_base_url += "/"
+    return urljoin(urljoin(url, shards_base_url), ".")
+
+
+class Shards(ShardBase):
+    """
+    Handle repodata_shards.msgpack.zst and individual per-package shards.
+    """
+
+    # cache for shards_base_url()
+    _shards_base_url = ""
+    _shards_base_url_key = (None, None)
+
+    def __init__(self, shards_index: ShardsIndexDict, url: str, cache: shards_cache.ShardCache):
+        """
+        Args:
+            shards_index: raw parsed msgpack dict
+            url: URL of repodata_shards.msgpack.zst
+        """
+        self.shards_index = shards_index
+        self.url = url
+        self.shards_cache = cache
+
+        # Use the channel's base URL to share session amongst subdir locations
+        channel_base_url = Channel(self.shards_base_url).base_url
+        self.session = get_session(channel_base_url)
+
+        self.repodata_no_packages = {
+            "info": shards_index["info"],
+            "packages": {},
+            "packages.conda": {},
+            "repodata_version": 2,
+        }
+
+        # used to write out repodata subset
+        # not used in traversal algorithm
+        self.visited: dict[str, ShardDict | None] = {}
+
+        # https://github.com/conda/conda-index/pull/209 ensures that sharded
+        # repodata will always include base_url, even if it is an empty string;
+        # rattler/pixi require these keys.
+        self._base_url = shards_index["info"]["base_url"]
+
+    @property
+    def package_names(self):
+        return self.packages_index.keys()
+
+    @property
+    def packages_index(self):
+        return self.shards_index["shards"]
+
+    @property
+    def shards_base_url(self) -> str:
+        """
+        Return self.url joined with shards_base_url.
+        Note shards_base_url can be a relative or an absolute url.
+        """
+        # could be simplified by restricting self.shards_index assignment
+        shards_base_url_ = self.shards_index["info"].get("shards_base_url", "")
+        cache_key = (self.url, shards_base_url_)
+        if self._shards_base_url_key != cache_key:
+            self._shards_base_url_key = cache_key
+            self._shards_base_url = _shards_base_url(self.url, shards_base_url_)
+        return self._shards_base_url
+
+    def shard_url(self, package: str) -> str:
+        """
+        Return shard URL for a given package.
+
+        Raise KeyError if package is not in the index.
+        """
+        shard_name = f"{bytes(self.packages_index[package]).hex()}.msgpack.zst"
+        # "Individual shards are stored under the URL <shards_base_url><sha256>.msgpack.zst"
+        return f"{self.shards_base_url}{shard_name}"
+
+    def shard_loaded(self, package: str) -> bool:
+        """
+        Return True if the given package's shard is in memory.
+        """
+        return package in self.visited
+
+    def visit_package(self, package: str) -> ShardDict:
+        """
+        Return a shard that is already in memory and mark as visited.
+        """
+        shard = self.visited[package]
+        return shard
+
+    def fetch_shard(self, package: str) -> ShardDict:
+        """
+        Fetch an individual shard for the given package.
+
+        Default implementation calls fetch_shards() with a single package.
+        Subclasses may override for more efficient single-fetch operations.
+
+        Raise KeyError if package is not in the index.
+        """
+        return self.fetch_shards([package])[package]
+
+    def fetch_shards(self, packages: Iterable[str]) -> dict[str, ShardDict]:
+        """
+        Return mapping of *package names* to Shard for given packages.
+
+        If a shard is already in self.visited, it is not fetched again.
+        """
+        results = {}
+
+        def fetch(s, url, package_to_fetch):
+            response = s.get(url)
+            response.raise_for_status()
+            data = response.content
+
+            return shards_cache.AnnotatedRawShard(
+                url=url, package=package_to_fetch, compressed_shard=data
+            )
+
+        packages = sorted(list(packages))
+        urls_packages = {}  # package shards to fetch
+        for package in packages:
+            if package in self.visited:
+                results[package] = self.visited[package]
+            else:
+                urls_packages[self.shard_url(package)] = package
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=_shards_connections()) as executor:
+            futures = {
+                executor.submit(fetch, self.session, url, package): (url, package)
+                for url, package in urls_packages.items()
+                if package not in results
+            }
+            for future in concurrent.futures.as_completed(futures):
+                log.debug(". %s", futures[future])
+                url, package = futures[future]
+                self._process_fetch_result(future, url, package, results)
+
+        self.visited.update(results)
+
+        return results
+
+    def _process_fetch_result(self, future, url, package, results):
+        """
+        Process a single fetched shard.
+        """
+        with conda_http_errors(url, package):
+            fetch_result = future.result()
+
+        # Decompress and save record
+        results[fetch_result.package] = msgpack.loads(
+            zstandard.decompress(
+                fetch_result.compressed_shard, max_output_size=ZSTD_MAX_SHARD_SIZE
+            )
+        )
+
+        # Cache fetched shard
+        self.shards_cache.insert(fetch_result)
+
+
+def repodata_shards(url, cache: RepodataCache) -> bytes:
+    """
+    Fetch shards index with cache.
+
+    Update cache state.
+
+    Return shards data, either newly fetched or from cache.
+
+    In offline mode, returns cached data even if expired. If no cache exists
+    in offline mode, raises RepodataIsEmpty to signal unavailability.
+    """
+    # In offline mode, return cached data if available, even if expired
+    if context.offline:
+        if cache.cache_path_shards.exists():
+            return cache.cache_path_shards.read_bytes()
+        else:
+            # In offline mode with no cache, signal that shards are not available.
+            # The caller (fetch_shards_index) catches RepodataIsEmpty and falls back to non-sharded repodata.
+            raise conda.gateways.repodata.RepodataIsEmpty(url, status_code=404, response=None)
+
+    session = get_session(url)
+
+    state = cache.state
+    headers = {}
+    etag = state.etag
+    last_modified = state.mod
+    if etag:
+        headers["If-None-Match"] = str(etag)
+    if last_modified:
+        headers["If-Modified-Since"] = str(last_modified)
+    filename = "repodata_shards.msgpack.zst"
+
+    with conda_http_errors(url, filename):
+        timeout = (
+            context.remote_connect_timeout_secs,
+            context.remote_read_timeout_secs,
+        )
+        response: Response = session.get(
+            url, headers=headers, proxies=session.proxies, timeout=timeout
+        )
+        response.raise_for_status()
+        response_bytes = response.content
+
+    if response.status_code == 304:
+        # should we save cache-control to state here to put another n
+        # seconds on the "make a remote request" clock and/or touch cache
+        # mtime
+        return cache.cache_path_shards.read_bytes()
+
+    saved_fields = {conda.gateways.repodata.URL_KEY: url}
+    for header, key in (
+        ("Etag", conda.gateways.repodata.ETAG_KEY),
+        (
+            "Last-Modified",
+            conda.gateways.repodata.LAST_MODIFIED_KEY,
+        ),
+        ("Cache-Control", conda.gateways.repodata.CACHE_CONTROL_KEY),
+    ):
+        _add_http_value_to_dict(response, header, saved_fields, key)
+
+    state.update(saved_fields)
+
+    # should we return the response and let caller save cache data to state?
+    return response_bytes
+
+
+# Like conda.gateways.repodata.jlap.fetch. If this returns True, then we mark
+# shards as not supported; otherwise, we will check again next time.
+def _is_http_error_most_400_codes(status_code: str | int) -> bool:
+    """
+    Determine whether the `HTTPError` is an HTTP 400 error code (except for 416).
+    """
+    return isinstance(status_code, int) and 400 <= status_code < 500 and status_code != 416
+
+
+def fetch_shards_index(
+    sd: SubdirData, cache: shards_cache.ShardCache | None = None
+) -> Shards | None:
+    """
+    Check a SubdirData's URL for shards.
+
+    Return shards index bytes from cache or network.
+    Return None if not found; caller should fetch normal repodata.
+
+    TODO: If this function fails to retrieve the sharded repodata index file, it will
+          mark it is as not supporting this feature in cache. This can problematic
+          because sometimes server errors can happen which will lead it to wrongly
+          assuming the channel doesn't support sharding. We need to rethink our
+          logic for determining shard support.
+    """
+
+    fetch = sd.repo_fetch
+    repo_cache = fetch.repo_cache
+
+    # cache.load_state() will clear the file on JSONDecodeError but cache.load()
+    # will raise the exception.
+    # repo_cache.load_state(
+    #     binary=True
+    # )  # won't succeed when .msgpack.zst is missing as it wants to compare the timestamp (returns empty state)
+
+    # Load state ourselves to avoid clearing when binary cached data is missing.
+    # If we fall back to monolithic repodata.json, the standard fetch code will
+    # load the state again in text mode.
+    try:
+        with repo_cache.lock("r+") as state_file:
+            # cannot use pathlib.read_text / write_text on any locked file, as
+            # it will release the lock early
+            state = json.loads(state_file.read())
+            repo_cache.state.update(state)
+    except (FileNotFoundError, json.JSONDecodeError):
+        pass
+
+    cache_state = repo_cache.state
+
+    if cache is None:
+        cache = shards_cache.ShardCache(Path(conda.gateways.repodata.create_cache_dir()))
+
+    if cache_state.should_check_format("shards"):
+        # look for shards index
+        shards_data = None
+        shards_index_url = f"{sd.url_w_subdir}/repodata_shards.msgpack.zst"
+
+        if not repo_cache.cache_path_shards.exists():
+            # avoid 304 not modified if we don't have the file
+            cache_state.etag = ""
+            cache_state.mod = ""
+        elif not repo_cache.stale():
+            # load from cache without network request
+            shards_data = repo_cache.cache_path_shards.read_bytes()
+
+        # If we don't have shards_data yet, try fetching (repodata_shards handles offline mode)
+        if shards_data is None:
+            try:
+                shards_data = repodata_shards(shards_index_url, repo_cache)
+                cache_state.set_has_format("shards", True)
+                # this will also set state["refresh_ns"] = time.time_ns(); we could
+                # call cache.refresh() if we got a 304 instead:
+                repo_cache.save(shards_data)
+            except conda.gateways.repodata.UnavailableInvalidChannel as err:
+                # repodata_shards converts HTTP errors to conda errors.
+                # fetch repodata.json / repodata.json.zst instead
+                if _is_http_error_most_400_codes(err.status_code):
+                    cache_state.set_has_format("shards", False)
+                repo_cache.refresh()
+            except conda.exceptions.CondaHTTPError as err:
+                # repodata_shards converts HTTP errors to conda errors.
+                # fetch repodata.json / repodata.json.zst instead
+                if (
+                    hasattr(err._caused_by, "response")
+                    and hasattr(err._caused_by.response, "status_code")
+                    and _is_http_error_most_400_codes(err._caused_by.response.status_code)
+                ):
+                    cache_state.set_has_format("shards", False)
+                repo_cache.refresh()
+
+        if shards_data:
+            # basic parse (move into caller?)
+            shards_index: ShardsIndexDict = msgpack.loads(
+                zstandard.decompress(shards_data, max_output_size=ZSTD_MAX_SHARD_SIZE)
+            )  # type: ignore
+            shards = Shards(shards_index, shards_index_url, cache)
+            return shards
+
+    return None
+
+
+def batch_retrieve_from_cache(sharded: list[Shards], packages: list[str]):
+    """
+    Given a list of Shards objects and a list of package names, fetch all URLs
+    from a shared local cache, and update Shards with those per-package shards.
+    Return the remaining URLs that must be fetched from the network.
+    """
+    sharded = [shardlike for shardlike in sharded if isinstance(shardlike, Shards)]
+
+    wanted = []
+    # XXX update batch_retrieve_from_cache to work with (Shards, package name)
+    # tuples instead of broadcasting across shards itself.
+    for shard in sharded:
+        for package_name in packages:
+            if package_name in shard:  # and not package_name in shard.visited
+                wanted.append((shard, package_name, shard.shard_url(package_name)))
+
+    log.debug("%d shards to fetch", len(wanted))
+
+    if not sharded:
+        log.debug("No sharded channels found.")
+        return wanted
+
+    shared_shard_cache = sharded[0].shards_cache
+    from_cache = shared_shard_cache.retrieve_multiple([shard_url for *_, shard_url in wanted])
+
+    # add fetched Shard objects to Shards objects visited dict
+    for shard, package, shard_url in wanted:
+        if from_cache_shard := from_cache.get(shard_url):
+            shard.visit_shard(package, from_cache_shard)
+
+    return wanted
+
+
+def batch_retrieve_from_network(wanted: list[tuple[Shards, str, str]]):
+    """
+    Given a list of (Shards, package name, shard URL) tuples, group by Shards and call fetch_shards
+    with a list of all URLs for that Shard.
+    """
+    shard_packages: dict[Shards, list[str]] = defaultdict(list)
+    for shard, package, _ in wanted:
+        shard_packages[shard].append(package)
+
+    # XXX it might be better to pull networking and Session() out of Shards(),
+    # so that we can e.g. use the same session for a Channel(); typically a
+    # noarch+arch pair of subdirs.
+    # Could we share a ThreadPoolExecutor and see better session utilization?
+    for shard, packages in shard_packages.items():
+        shard.fetch_shards(packages)
+
+
+def fetch_channels(url_to_channel: dict[str, Channel]) -> dict[str, ShardBase]:
+    """
+    Args:
+        url_to_channel: not modified, must already be expanded to subdirs.
+
+    Returns:
+        A dict mapping channel URLs to `Shard` or `ShardLike` objects.
+    """
+    # retain order from incoming dict:
+    channel_data: dict[str, ShardBase | None] = {url: None for url in url_to_channel}
+
+    # share single disk cache for all Shards() instances
+    cache = shards_cache.ShardCache(Path(conda.gateways.repodata.create_cache_dir()))
+
+    # The parallel version may reorder channels, does this matter?
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=_shards_connections()) as executor:
+        futures = {
+            executor.submit(fetch_shards_index, SubdirData(channel), cache): channel_url
+            for (channel_url, channel) in url_to_channel.items()
+        }
+        futures_non_sharded = {}
+
+        for future in concurrent.futures.as_completed(futures):
+            channel_url = futures[future]
+            found = future.result()
+            if found:
+                channel_data[channel_url] = found
+            else:
+                futures_non_sharded[
+                    executor.submit(
+                        SubdirData(Channel(channel_url)).repo_fetch.fetch_latest_parsed
+                    )
+                ] = channel_url
+
+        # if all are None then don't do ShardLike...
+
+        for future in concurrent.futures.as_completed(futures_non_sharded):
+            channel_url = futures_non_sharded[future]
+            repodata_json, _ = future.result()
+            # the filename is not strictly repodata.json since we could have
+            # fetched the same data from repodata.json.zst; but makes the
+            # urljoin consistent with shards which end with
+            # /repodata_shards.msgpack.zst
+            url = f"{channel_url}/repodata.json"
+            found = ShardLike(repodata_json, url)
+            channel_data[channel_url] = found
+
+    return {url: channel for url, channel in channel_data.items() if channel is not None}

--- a/conda_rattler_solver/shards.py
+++ b/conda_rattler_solver/shards.py
@@ -20,6 +20,7 @@ from urllib.parse import urljoin
 
 import conda.exceptions
 import conda.gateways.repodata
+import rattler
 import msgpack
 import zstandard
 from conda.base.context import context
@@ -30,7 +31,6 @@ from conda.gateways.repodata import (
     conda_http_errors,
 )
 from conda.models.channel import Channel
-from libmambapy.bindings import specs
 
 from . import shards_cache
 
@@ -43,9 +43,12 @@ if TYPE_CHECKING:
     from conda.gateways.repodata import RepodataCache
     from requests import Response
 
-    from conda_libmamba_solver.shards_typing import RepodataDict, ShardsIndexDict
-
-    from .shards_typing import PackageRecordDict, ShardDict
+    from .shards_typing import (
+        PackageRecordDict,
+        RepodataDict,
+        ShardDict,
+        ShardsIndexDict,
+    )
 
 SHARDS_CONNECTIONS_DEFAULT = 10
 ZSTD_MAX_SHARD_SIZE = 2**20 * 16  # maximum size necessary when compressed data has no size header
@@ -90,9 +93,7 @@ def spec_to_package_name(spec: str) -> str:
     """
     # Note: hope for no MatchSpec-without-name in repodata, although it is
     # possible in the MatchSpec grammar.
-    parsed_spec = specs.MatchSpec.parse(spec)
-    name = str(parsed_spec.name)
-    return name
+    return rattler.MatchSpec(spec).name.normalized
 
 
 def shard_mentioned_packages(shard: ShardDict) -> Iterable[str]:

--- a/conda_rattler_solver/shards_cache.py
+++ b/conda_rattler_solver/shards_cache.py
@@ -1,0 +1,159 @@
+# Copyright (C) 2022 Anaconda, Inc
+# Copyright (C) 2023 conda
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Cache suitable for shards, not allowed to change because they are named
+after their own sha256 hash.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import msgpack
+import zstandard
+from conda.gateways.disk.delete import unlink_or_rename_to_trash
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from .shards_typing import ShardDict
+
+log = logging.getLogger(__name__)
+
+SHARD_CACHE_NAME = "repodata_shards.db"
+ZSTD_MAX_SHARD_SIZE = 2**20 * 16  # maximum size necessary when compresed data has no size header
+
+
+@dataclass
+class AnnotatedRawShard:
+    def __init__(self, url: str, package: str, compressed_shard: bytes):
+        # prevent easy mistake of swapping url, package
+        assert "://" in url
+        assert "://" not in package
+
+        self.url = url
+        self.package = package  # remove this field to avoid confusion?
+        self.compressed_shard = compressed_shard
+
+    url: str
+    package: str
+    compressed_shard: bytes
+
+
+def connect(dburi="cache.db"):
+    """
+    Get database connection.
+
+    dburi: uri-style sqlite database filename; accepts certain ?= parameters.
+    """
+    conn = sqlite3.connect(dburi, uri=True)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+class ShardCache:
+    """
+    Handle caching for individual shards (not the index of shards).
+    """
+
+    def __init__(self, base: Path, create=True):
+        """
+        base: directory and filename prefix for cache.
+        """
+        self.base = base
+        self.connect()
+
+    def copy(self):
+        """
+        Copy cache with new connection. Useful for threads.
+        """
+        return ShardCache(self.base, create=False)
+
+    def connect(self, create=True):
+        """
+        Args:
+            create: if True, create table if not exists.
+        """
+        dburi = (self.base / SHARD_CACHE_NAME).as_uri()
+        self.conn = connect(dburi)
+        if not create:
+            return
+        # this schema will also get confused if we merge packages into a single
+        # shard, but the package name should be advisory.
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS shards ("
+            "url TEXT PRIMARY KEY, package TEXT, shard BLOB, "
+            "timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP)"
+        )
+
+    def insert(self, raw_shard: AnnotatedRawShard):
+        """
+        Args:
+            url: of shard
+            package: package name
+            raw_shard: msgpack.zst compressed shard data
+        """
+        # decompress and return shard for convenience, also to validate? unless
+        # caller would rather retrieve the shard from another thread.
+        with self.conn as c:
+            c.execute(
+                "INSERT OR IGNORE INTO SHARDS (url, package, shard) VALUES (?, ?, ?)",
+                (raw_shard.url, raw_shard.package, raw_shard.compressed_shard),
+            )
+
+    def retrieve(self, url) -> ShardDict | None:
+        with self.conn as c:
+            row = c.execute("SELECT shard FROM shards WHERE url = ?", (url,)).fetchone()
+            return (
+                msgpack.loads(
+                    zstandard.decompress(row["shard"], max_output_size=ZSTD_MAX_SHARD_SIZE)
+                )
+                if row
+                else None
+            )  # type: ignore
+
+    def retrieve_multiple(self, urls: list[str]) -> dict[str, ShardDict | None]:
+        """
+        Query database for cached shard urls.
+
+        Return a dict of urls in cache mapping to the Shard or None if not present.
+        """
+        if not urls:
+            return {}  # this optimization does not save a noticeable amount of time.
+
+        # In one test reusing the context saves difference between .006s and .01s
+        # We could make this a threadlocal.
+        dctx = zstandard.ZstdDecompressor()
+
+        query = f"SELECT url, shard FROM shards WHERE url IN ({','.join(('?',) * len(urls))}) ORDER BY url"
+        with self.conn as c:
+            result: dict[str, ShardDict | None] = {
+                row["url"]: msgpack.loads(
+                    dctx.decompress(row["shard"], max_output_size=ZSTD_MAX_SHARD_SIZE)
+                )
+                if row
+                else None
+                for row in c.execute(query, urls)  # type: ignore
+            }
+            return result
+
+    def clear_cache(self):
+        """
+        Truncate the database by removing all rows from tables
+        """
+        with self.conn as c:
+            c.execute("DELETE FROM shards")
+
+    def remove_cache(self):
+        """
+        Remove the sharded cache database.
+        """
+        # This function appears to support `Path()` except on Windows
+        # `os.rename(path, path + ".conda_trash")` fails:
+        self.conn.close()
+        unlink_or_rename_to_trash(str(self.base / SHARD_CACHE_NAME))

--- a/conda_rattler_solver/shards_subset.py
+++ b/conda_rattler_solver/shards_subset.py
@@ -35,8 +35,9 @@ found.
 The following constructs several repodata (`noarch` and `linux-64`) from a
 single channel name and a list of root packages:
 
-``` from conda.models.channel import Channel from
-conda_libmamba_solver.shards_subset import build_repodata_subset
+```
+from conda.models.channel import Channel
+from conda_rattler_solver.shards_subset import build_repodata_subset
 
 channel = Channel("conda-forge-sharded/linux-64") channel_data =
 build_repodata_subset(["python", "pandas"], [channel.url()]) repodata = {}
@@ -68,9 +69,8 @@ import msgpack
 import zstandard
 from conda.base.context import context
 
-from conda_libmamba_solver import shards_cache
-from conda_libmamba_solver.shards_cache import AnnotatedRawShard
-
+from . import shards_cache
+from .shards_cache import AnnotatedRawShard
 from .shards import (
     ZSTD_MAX_SHARD_SIZE,
     Shards,
@@ -90,12 +90,9 @@ if TYPE_CHECKING:
 
     from conda.models.channel import Channel
 
-    from conda_libmamba_solver.shards_cache import ShardCache
-    from conda_libmamba_solver.shards_typing import ShardDict
-
-    from .shards import (
-        ShardBase,
-    )
+    from .shards_cache import ShardCache
+    from .shards_typing import ShardDict
+    from .shards import ShardBase
 
 # Waiting for worker threads to shutdown cleanly, or raise error.
 THREAD_WAIT_TIMEOUT = 5  # seconds

--- a/conda_rattler_solver/shards_subset.py
+++ b/conda_rattler_solver/shards_subset.py
@@ -1,0 +1,693 @@
+# Copyright (C) 2022 Anaconda, Inc
+# Copyright (C) 2023 conda
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Sharded repodata subsets.
+
+Traverse dependencies of installed and to-be-installed packages to generate a
+useful subset for the solver.
+
+The algorithm developed here is a direct result of the following CEP:
+
+- https://conda.org/learn/ceps/cep-0016 (Sharded Repodata)
+
+In this algorithm we treat a (channel, package name) as a node, its dependencies
+as edges. We then traverse all edges to discover all reachable (channel, package
+name) tuples. The solver should be able to find a solution with only this
+subset.
+
+This subset is overgenerous since the user is unlikely to want to install very
+old packages and their dependencies. If this is too slow, we could deploy
+heuristics that automatically ignore older package versions. We could also allow
+the user to configure minimum versions of common packages and ignore older
+versions and their dependencies, falling back to a full solve if unsatisfiable.
+
+We treat both sharded and monolithic repodata as if they were made up of
+per-package shards, computing a subset of both. This is because it is possible
+for the monolithic repodata to mention packages that exist in the true sharded
+repodata but would not be found by only traversing the shards.
+
+We treat all repodata as sharded, even if no actual sharded repodata has been
+found.
+
+## Example usage
+
+The following constructs several repodata (`noarch` and `linux-64`) from a
+single channel name and a list of root packages:
+
+``` from conda.models.channel import Channel from
+conda_libmamba_solver.shards_subset import build_repodata_subset
+
+channel = Channel("conda-forge-sharded/linux-64") channel_data =
+build_repodata_subset(["python", "pandas"], [channel.url()]) repodata = {}
+
+for url in channel_data:
+    repodata[url] = channel_data.build_repodata()
+
+# ... this is what's fed to the solver ```
+
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import queue
+import sys
+import threading
+from collections import deque
+from concurrent.futures import Future, ThreadPoolExecutor
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from queue import SimpleQueue
+from typing import TYPE_CHECKING
+
+import conda.gateways.repodata
+import msgpack
+import zstandard
+from conda.base.context import context
+
+from conda_libmamba_solver import shards_cache
+from conda_libmamba_solver.shards_cache import AnnotatedRawShard
+
+from .shards import (
+    ZSTD_MAX_SHARD_SIZE,
+    Shards,
+    _shards_connections,
+    batch_retrieve_from_cache,
+    batch_retrieve_from_network,
+    fetch_channels,
+    shard_mentioned_packages,
+)
+
+log = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Iterator, Sequence
+    from queue import SimpleQueue as Queue
+    from typing import Literal, TypeVar
+
+    from conda.models.channel import Channel
+
+    from conda_libmamba_solver.shards_cache import ShardCache
+    from conda_libmamba_solver.shards_typing import ShardDict
+
+    from .shards import (
+        ShardBase,
+    )
+
+# Waiting for worker threads to shutdown cleanly, or raise error.
+THREAD_WAIT_TIMEOUT = 5  # seconds
+REACHABLE_PIPELINED_MAX_TIMEOUTS = 10  # number of times we can timeout waiting for shards
+
+
+@dataclass(order=True)
+class Node:
+    distance: int = sys.maxsize
+    package: str = ""
+    channel: str = ""
+    visited: bool = False
+    shard_url: str = ""
+
+    def to_id(self) -> NodeId:
+        return NodeId(self.package, self.channel, self.shard_url)
+
+
+@dataclass(order=True, eq=True, frozen=True)
+class NodeId:
+    package: str
+    channel: str
+    shard_url: str = ""
+
+    def __hash__(self):
+        return hash((self.package, self.channel, self.shard_url))
+
+
+def _nodes_from_packages(
+    root_packages: list[str], shardlikes: Iterable[ShardBase]
+) -> Iterator[tuple[NodeId, Node]]:
+    """
+    Yield (NodeId, Node) for all root packages found in shardlikes.
+    """
+    for package in root_packages:
+        for shardlike in shardlikes:
+            if package in shardlike:
+                node = Node(0, package, shardlike.url, shard_url=shardlike.shard_url(package))
+                node_id = node.to_id()
+                yield node_id, node
+
+
+def filter_redundant_packages(repodata: ShardDict, use_only_tar_bz2=False) -> ShardDict:
+    """
+    Given repodata or a single shard, remove any .tar.bz2 packages that have a
+    .conda counterpart.
+
+    Return a shallow copy if use_only_tar_bz2==False, else unmodified input.
+    """
+    if use_only_tar_bz2:
+        return repodata
+
+    _tar_bz2 = ".tar.bz2"
+    _conda = ".conda"
+    _len_tar_bz2 = len(_tar_bz2)
+
+    legacy_packages = repodata.get("packages", {})
+    conda_packages = repodata.get("packages.conda", {})
+
+    return {
+        **repodata,
+        "packages": {
+            k: v
+            for k, v in legacy_packages.items()
+            if f"{k[:-_len_tar_bz2]}{_conda}" not in conda_packages
+        },
+    }
+
+
+@dataclass
+class RepodataSubset:
+    nodes: dict[NodeId, Node]
+    shardlikes: Sequence[ShardBase]
+    DEFAULT_STRATEGY = "pipelined"
+
+    def __init__(self, shardlikes: Iterable[ShardBase]):
+        self.nodes = {}
+        self.shardlikes = list(shardlikes)
+        self._use_only_tar_bz2 = context.use_only_tar_bz2
+
+    @classmethod
+    def has_strategy(cls, strategy: str) -> bool:
+        """
+        Return True if this class provides the named shard traversal strategy.
+        """
+        return hasattr(cls, f"reachable_{strategy}")
+
+    def neighbors(self, node: Node) -> Iterator[Node]:
+        """
+        Retrieve all unvisited neighbors of a node
+
+        Neighbors in the context are dependencies of a package
+        """
+        discovered = set()
+
+        for shardlike in self.shardlikes:
+            if node.package not in shardlike:
+                continue
+
+            # check that we don't fetch the same shard twice...
+            shard = shardlike.fetch_shard(
+                node.package
+            )  # XXX this is the only place that in-memory (repodata.json) shards are found for the first time
+
+            shard = filter_redundant_packages(shard, self._use_only_tar_bz2)
+            shardlike.visit_shard(node.package, shard)
+
+            for package in shard_mentioned_packages(shard):
+                node_id = NodeId(package, shardlike.url)
+
+                if node_id not in self.nodes:
+                    self.nodes[node_id] = Node(node.distance + 1, package, shardlike.url)
+                    yield self.nodes[node_id]
+
+                    if package not in discovered:
+                        # now this is per package name, not per (name, channel) tuple
+                        discovered.add(package)
+
+    def outgoing(self, node: Node):
+        """
+        All nodes that can be reached by this node, plus cost.
+        """
+        # If we set a greater cost for sharded repodata than the repodata that
+        # is already in memory and tracked nodes as (channel, package) tuples,
+        # we might be able to find more shards-to-fetch-in-parallel more
+        # quickly. On the other hand our goal is that the big channels will all
+        # be sharded.
+        for n in self.neighbors(node):
+            yield n, 1
+
+    def reachable(self, root_packages, *, strategy=DEFAULT_STRATEGY) -> None:
+        """
+        Run named reachability strategy or the default.
+
+        Update `self.shardlikes` with reachable package records. Later,
+        [shardlike.build_repodata() for shardlike in shardlikes] can be used to
+        generate repodata.json-format subsets of each channel.
+        """
+        return getattr(self, f"reachable_{strategy}")(root_packages)
+
+    def reachable_bfs(self, root_packages):
+        """
+        Fetch all packages reachable from `root_packages`' by following
+        dependencies using the "breadth-first search" algorithm.
+
+        Update associated `self.shardlikes` to contain enough data to build a
+        repodata subset.
+        """
+        self.nodes = dict(_nodes_from_packages(root_packages, self.shardlikes))
+
+        node_queue = deque(self.nodes.values())
+        sharded = [s for s in self.shardlikes if isinstance(s, Shards)]
+
+        while node_queue:
+            # Batch fetch all nodes at current level
+            to_retrieve = {node.package for node in node_queue if not node.visited}
+            if to_retrieve:
+                not_in_cache = batch_retrieve_from_cache(sharded, sorted(to_retrieve))
+                batch_retrieve_from_network(not_in_cache)
+
+            # Process one level
+            level_size = len(node_queue)
+            for _ in range(level_size):
+                node = node_queue.popleft()
+                if node.visited:  # pragma: no cover
+                    continue  # we should never add visited nodes to node_queue
+                node.visited = True
+
+                for next_node, _ in self.outgoing(node):
+                    if not next_node.visited:
+                        node_queue.append(next_node)
+
+    def reachable_pipelined(self, root_packages):
+        """
+        Fetch all packages reachable from `root_packages`' by following
+        dependencies.
+
+        Build repodata subset using concurrent threads to follow dependencies,
+        fetch from cache, and fetch from network.
+        """
+
+        # In offline mode shards are retrieved from the cache database as usual,
+        # but cache misses are forwarded to offline_nofetch_thread returning
+        # empty shards.
+        if context.offline:
+            network_worker = offline_nofetch_thread
+        else:
+            network_worker = network_fetch_thread
+
+        return self._reachable_pipelined(root_packages, network_worker=network_worker)
+
+    def _reachable_pipelined(
+        self,
+        root_packages,
+        network_worker: Callable[
+            [
+                Queue[Sequence[NodeId] | None],
+                Queue[list[tuple[NodeId, ShardDict] | Exception] | None],
+                ShardCache,
+                Sequence[ShardBase],
+            ],
+            None,
+        ],
+    ):
+        """
+        Set up queues and threads for shard traversal with a configurable
+        network_worker. Called by reachable_pipelined()
+        """
+
+        # Ignore cache on shards object, use our own. Necessary if there are no
+        # sharded channels.
+        cache = shards_cache.ShardCache(Path(conda.gateways.repodata.create_cache_dir()))
+
+        cache_in_queue: SimpleQueue[list[NodeId] | None] = SimpleQueue()
+        shard_out_queue: SimpleQueue[list[tuple[NodeId, ShardDict]] | Exception] = SimpleQueue()
+        cache_miss_queue: SimpleQueue[list[NodeId] | None] = SimpleQueue()
+
+        cache_thread = threading.Thread(
+            target=cache_fetch_thread,
+            args=(cache_in_queue, shard_out_queue, cache_miss_queue, cache),
+            daemon=True,  # may have to set to False if we ever want to run in a subinterpreter
+        )
+
+        network_thread = threading.Thread(
+            target=network_worker,
+            args=(cache_miss_queue, shard_out_queue, cache, self.shardlikes),
+            daemon=True,
+        )
+
+        try:
+            cache_thread.start()
+            network_thread.start()
+            self._pipelined_traversal(
+                root_packages, cache_in_queue, shard_out_queue, cache_thread, network_thread
+            )
+        finally:
+            cache_in_queue.put(None)
+            # These should finish almost immediately, but if not, raise an error:
+            cache_thread.join(THREAD_WAIT_TIMEOUT)
+            network_thread.join(THREAD_WAIT_TIMEOUT)
+
+    def _pipelined_traversal(
+        self,
+        root_packages,
+        cache_in_queue: Queue[list[NodeId] | None],
+        shard_out_queue: Queue[list[tuple[NodeId, ShardDict]] | Exception],
+        cache_thread: threading.Thread,
+        network_thread: threading.Thread,
+    ):
+        """
+        Run reachability algorithm given queues to submit and receive shards.
+        """
+        shardlikes_by_url = {s.url: s for s in self.shardlikes}
+        pending: set[NodeId] = set()
+        in_flight: set[NodeId] = set()
+        timeouts = 0
+
+        self.nodes = {}
+
+        # create start condition
+        parent_node = Node(0)
+        pending.update(self.visit_node(parent_node, root_packages))
+
+        def pump():
+            """
+            Find shards we already have and those we need. Submit those need to
+            cache_in_queue, those we have to shard_out_queue.
+            """
+            have, need = self.drain_pending(pending, shardlikes_by_url)
+            if need:
+                in_flight.update(need)
+                cache_in_queue.put(need)
+            if have:
+                in_flight.update(node_id for node_id, _ in have)
+                # All shards go through shard_out queue to be processed at
+                # shard_out_queue.get(). Whether they come from cache, network,
+                # or for repodata.json we "have" them (already in memory).
+                shard_out_queue.put(have)
+            return len(have) + len(need)
+
+        def log_timeout():
+            """
+            Log timeout information and raise TimeoutError if max timeouts
+            exceeded.
+            """
+            nonlocal timeouts
+            timeouts += 1
+            log.debug("Shard timeout %s", timeouts)
+            log.debug("in_flight: %s...", sorted(str(node_id) for node_id in in_flight)[:10])
+            log.debug("nodes: %d", len(self.nodes))
+            log.debug("cache_thread.is_alive(): %s", cache_thread.is_alive())
+            log.debug("network_thread.is_alive(): %s", network_thread.is_alive())
+            log.debug("shard_out_queue.qsize(): %s", shard_out_queue.qsize())
+            if timeouts > REACHABLE_PIPELINED_MAX_TIMEOUTS:
+                raise TimeoutError("Timeout while fetching repodata shards.")
+
+        while True:
+            pump()
+            if not in_flight:  # pending is empty right after calling pump()
+                log.debug("All shards have finished processing.")
+                break
+
+            try:
+                new_shards = shard_out_queue.get(timeout=1)
+                if new_shards is None:
+                    break
+
+                if isinstance(new_shards, Exception):  # error propagated from worker thread
+                    raise new_shards
+
+            except queue.Empty:
+                log_timeout()
+                continue
+
+            for node_id, shard in new_shards:
+                in_flight.remove(node_id)
+
+                # remove_legacy_packages if the ".conda" format is enabled /
+                # conda is not in ".tar.bz2 only" mode.
+                shard = filter_redundant_packages(shard, self._use_only_tar_bz2)
+
+                # add shard to appropriate ShardLike
+                parent_node = self.nodes[node_id]
+                shardlike = shardlikes_by_url[node_id.channel]
+                shardlike.visit_shard(node_id.package, shard)
+
+                pending.update(self.visit_node(parent_node, shard_mentioned_packages(shard)))
+
+    def visit_node(self, parent_node: Node, mentioned_packages: Iterable[str]) -> Iterable[NodeId]:
+        """Broadcast mentioned packages across channels. yield pending NodeId's."""
+        # NOTE we have visit for Nodes which is used in the graph traversal
+        # algorithm, and a separate visit for ShardBase which means "include
+        # this package in the output repodata".
+        for package in mentioned_packages:
+            for shardlike in self.shardlikes:
+                if package in shardlike:
+                    new_node_id = NodeId(package, shardlike.url, shardlike.shard_url(package))
+                    if new_node_id not in self.nodes:
+                        new_node = Node(
+                            distance=parent_node.distance + 1,
+                            package=new_node_id.package,
+                            channel=new_node_id.channel,
+                            shard_url=new_node_id.shard_url,
+                        )
+                        self.nodes[new_node_id] = new_node
+                        yield new_node_id
+
+        parent_node.visited = True
+
+    def drain_pending(
+        self, pending: set[NodeId], shardlikes_by_url: dict[str, ShardBase]
+    ) -> tuple[list[tuple[NodeId, ShardDict]], list[NodeId]]:
+        """
+        Check pending for in-memory shards.
+        Clear pending.
+
+        Return a list of shards we have and shards we need to fetch.
+        """
+        shards_need = []
+        shards_have = []
+        for node_id in pending:
+            # we should already have these nodes.
+            shardlike = shardlikes_by_url[node_id.channel]
+            if shardlike.shard_loaded(node_id.package):  # for monolithic repodata
+                shards_have.append((node_id, shardlike.visit_package(node_id.package)))
+            else:
+                if self.nodes[node_id].visited:  # pragma: no cover
+                    log.debug("Skip visited, should not be reached")
+                    continue
+                shards_need.append(node_id)
+        pending.clear()
+        return shards_have, shards_need
+
+
+def build_repodata_subset(
+    root_packages: Iterable[str],
+    channels: dict[str, Channel],
+    algorithm: Literal["bfs", "pipelined"] = RepodataSubset.DEFAULT_STRATEGY,
+) -> dict[str, ShardBase]:
+    """
+    Retrieve all necessary information to build a repodata subset.
+
+    Params:
+        root_packages: iterable of installed and requested package names
+        channels: Channel objects; dict form preferred.
+        algorithm: desired traversal algorithm
+    """
+    channel_data = fetch_channels(channels)
+
+    subset = RepodataSubset((*channel_data.values(),))
+    subset.reachable(root_packages, strategy=algorithm)
+    log.debug("%d (channel, package) nodes discovered", len(subset.nodes))
+
+    return channel_data
+
+
+# region workers
+
+if TYPE_CHECKING:
+    _T = TypeVar("_T")
+
+
+def combine_batches_until_none(
+    in_queue: Queue[Sequence[_T] | None],
+) -> Iterator[Sequence[_T]]:
+    """
+    Combine lists from in_queue until we see None. Yield combined lists.
+    """
+    running = True
+    while running:
+        try:
+            # Add timeout to prevent indefinite blocking if producer thread fails
+            batch = in_queue.get(timeout=5)
+            if batch is None:
+                break
+        except queue.Empty:
+            # If we timeout, continue waiting - producer might still send data
+            continue
+
+        node_ids = list(batch)
+        with suppress(queue.Empty):
+            while True:  # loop exits with break or queue.Empty exception
+                batch = in_queue.get_nowait()
+                if batch is None:
+                    # do the work but then quit
+                    running = False
+                    break
+                else:
+                    node_ids.extend(batch)
+        yield node_ids
+
+
+def exception_to_queue(func):
+    """
+    Decorator to send unhandled exceptions to the second argument out_queue.
+    """
+
+    @functools.wraps(func)
+    def wrapper(in_queue, out_queue, *args, **kwargs):
+        try:
+            return func(in_queue, out_queue, *args, **kwargs)
+        except Exception as e:
+            in_queue.put(None)  # signal termination
+            out_queue.put(e)
+
+    return wrapper
+
+
+@exception_to_queue
+def cache_fetch_thread(
+    in_queue: Queue[Sequence[NodeId] | None],
+    shard_out_queue: Queue[Sequence[tuple[NodeId, ShardDict] | Exception] | None],
+    network_out_queue: Queue[Sequence[NodeId] | None],
+    cache: ShardCache,
+):
+    """
+    Fetch batches of shards from cache until in_queue sees None. Enqueue found
+    shards to shard_out_queue, and not found shards to network_out_queue.
+
+    When we see None on in_queue, send None to both out queues and exit.
+
+    Args:
+        in_queue: NodeId (URLs) to fetch.
+        shard_out_queue: fetched shards sent to queue.
+        network_out_queue: cache misses forwarded to queue. Same queue is
+            network_fetch_thread's in_queue.
+        cache: used to retrieve shards.
+    """
+    cache = cache.copy()
+
+    for node_ids in combine_batches_until_none(in_queue):
+        cached = cache.retrieve_multiple([node_id.shard_url for node_id in node_ids])
+
+        # should we add this into retrieve_multiple?
+        found: list[tuple[NodeId, ShardDict]] = []
+        not_found: list[NodeId] = []
+        for node_id in node_ids:
+            if shard := cached.get(node_id.shard_url):
+                found.append((node_id, shard))
+            else:
+                not_found.append(node_id)
+
+        # Might wake up the network thread by calling it first:
+        if not_found:
+            network_out_queue.put(not_found)
+        if found:
+            shard_out_queue.put(found)
+
+    network_out_queue.put(None)
+    shard_out_queue.put(None)
+
+
+@exception_to_queue
+def network_fetch_thread(
+    in_queue: Queue[Sequence[NodeId] | None],
+    shard_out_queue: Queue[list[tuple[NodeId, ShardDict] | Exception] | None],
+    cache: ShardCache,
+    shardlikes: Sequence[ShardBase],
+):
+    """
+    Fetch shards from the network that are received on in_queue, until we see
+    None.
+
+    Unhandled exceptions also go to shard_out_queue, and exit this thread.
+
+    Args:
+        in_queue: NodeId (URLs) to fetch.
+        shard_out_queue: fetched shards sent to queue.
+        cache: once shards are decoded they are stored in cache.
+        shardlikes: list of (network-only) shard index objects.
+    """
+    cache = cache.copy()
+    dctx = zstandard.ZstdDecompressor(max_window_size=ZSTD_MAX_SHARD_SIZE)
+    shardlikes_by_url = {s.url: s for s in shardlikes}
+
+    def fetch(s, url: str, node_id: NodeId):
+        response = s.get(url)
+        response.raise_for_status()
+        data = response.content
+        return url, node_id, data
+
+    def submit(node_id: NodeId):
+        # this worker should only receive network node_id's:
+        shardlike = shardlikes_by_url[node_id.channel]
+        if not isinstance(shardlike, Shards):
+            raise TypeError("network_fetch_thread got non-network shardlike")
+        session = shardlike.session
+        url = shardlikes_by_url[node_id.channel].shard_url(node_id.package)
+        return executor.submit(fetch, session, url, node_id)
+
+    def handle_result(future: Future):
+        url, node_id, data = future.result()
+        log.debug("Fetch thread got %s (%s bytes)", url, len(data))
+        # Decompress and parse. If it decodes as
+        # msgpack.zst, insert into cache. Then put "known
+        # good" shard into out queue.
+        shard: ShardDict = msgpack.loads(
+            dctx.decompress(data, max_output_size=ZSTD_MAX_SHARD_SIZE)
+        )  # type: ignore[assign]
+        # We could send this back into the cache thread instead to
+        # serialize access to sqlite3 if lock contention becomes an issue.
+        cache.insert(AnnotatedRawShard(url, node_id.package, data))
+        shard_out_queue.put([(node_id, shard)])
+
+    def result_to_in_queue(future: Future):
+        # Simplify waiting by putting responses back into in_queue. This
+        # function is called in the ThreadPoolExecutor's thread, but we want to
+        # serialize result processing in the network_fetch_thread.
+
+        # Not in our signature; the caller doesn't need to know we are putting
+        # Future in here as well.
+        in_queue.put([future])  # type: ignore
+
+    with ThreadPoolExecutor(max_workers=_shards_connections()) as executor:
+        for node_ids_and_results in combine_batches_until_none(in_queue):
+            for node_id_or_result in node_ids_and_results:
+                if isinstance(node_id_or_result, Future):
+                    handle_result(node_id_or_result)
+                else:
+                    future = submit(node_id_or_result)
+                    future.add_done_callback(result_to_in_queue)
+
+        # TODO call executor.shutdown(cancel_futures=True) on error or otherwise
+        # prevent new HTTP requests from being started e.g. "skip" flag in
+        # fetch() function. Also possible to shutdown(wait=False).
+
+
+@exception_to_queue
+def offline_nofetch_thread(
+    in_queue: Queue[Sequence[NodeId] | None],
+    shard_out_queue: Queue[list[tuple[NodeId, ShardDict] | Exception] | None],
+    cache: ShardCache,
+    shardlikes: Sequence[ShardBase],
+):
+    """
+    For offline mode, where network requests are not allowed.
+    Pretend that every network request is an empty shard.
+    Don't save those to the cache.
+
+    Depending on how many shards are in sqlite3 and which packages were requested, the user may or may not get enough repodata for a solution.
+
+    Args:
+        in_queue: NodeId (URLs) to fetch.
+        shard_out_queue: fetched shards sent to queue.
+        cache: once shards are decoded they are stored in cache.
+        shardlikes: list of (network-only) shard index objects.
+    """
+
+    for node_ids in combine_batches_until_none(in_queue):
+        for node_id in node_ids:
+            shard: ShardDict = {"packages": {}, "packages.conda": {}}
+            shard_out_queue.put([(node_id, shard)])
+
+
+# endregion

--- a/conda_rattler_solver/shards_typing.py
+++ b/conda_rattler_solver/shards_typing.py
@@ -1,0 +1,68 @@
+# Copyright (C) 2022 Anaconda, Inc
+# Copyright (C) 2023 conda
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+TypedDict declarations for shards.
+
+These are helpful for auto-complete, but do not validate at runtime and are not
+normative. They are intentionally not shared with another project (conda) to
+reduce coupling.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict
+
+if TYPE_CHECKING:
+    from typing import NotRequired
+
+
+class PackageRecordDict(TypedDict):
+    """
+    Basic package attributes that this module cares about.
+    """
+
+    name: str
+    version: str
+    build: str
+    build_number: int
+    sha256: NotRequired[str | bytes]
+    md5: NotRequired[str | bytes]
+    depends: list[str]
+    constrains: NotRequired[list[str]]
+    noarch: NotRequired[str]
+
+
+# in this style because "packages.conda" is not a Python identifier
+ShardDict = TypedDict(
+    "ShardDict",
+    {
+        "packages": dict[str, PackageRecordDict],
+        "packages.conda": dict[str, PackageRecordDict],
+    },
+)
+
+
+class RepodataInfoDict(TypedDict):  # noqa: F811
+    base_url: str  # where packages are stored
+    shards_base_url: str  # where shards are stored
+    subdir: str
+
+
+class RepodataDict(ShardDict):
+    """
+    Packages plus info.
+    """
+
+    info: RepodataInfoDict
+    repodata_version: int
+
+
+class ShardsIndexDict(TypedDict):
+    """
+    Shards index as deserialized from repodata_shards.msgpack.zst
+    """
+
+    info: RepodataInfoDict
+    version: int  # TODO conda-index currently uses 'repodata_version' here
+    shards: dict[str, bytes]

--- a/conda_rattler_solver/solver.py
+++ b/conda_rattler_solver/solver.py
@@ -139,6 +139,7 @@ class RattlerSolver(Solver):
                 channels=channels,
                 conda_build_channels=conda_build_channels,
                 subdirs=self.subdirs,
+                in_state=in_state,
             )
             out_state.check_for_pin_conflicts(index)
 
@@ -232,12 +233,14 @@ class RattlerSolver(Solver):
         channels: Iterable[Channel],
         conda_build_channels: Iterable[Channel],
         subdirs: Iterable[str],
+        in_state: SolverInputState,
     ) -> RattlerIndexHelper:
         index = RattlerIndexHelper(
             channels=[*conda_build_channels, *channels],
             subdirs=subdirs,
             repodata_fn=self._repodata_fn,
             pkgs_dirs=context.pkgs_dirs if context.offline else (),
+            in_state=in_state,
         )
         for channel in conda_build_channels:
             index.reload_channel(channel)


### PR DESCRIPTION
Copied all the `shards*.py` modules and adjusted `index.py` to use shards.

This is not supposed to be merged, just looking into how tricky this would be:

- The changes needed in `shards*.py` are trivial (only replace `libmambapy.specs.MatchSpec.parse()` with `rattler.MatchSpec()`)
- The integrations in `index.py` are not so trivial but also ok.

I recommend moving the `shards*.py` collection to `conda/conda` and allowing a certain `MatchSpec` interface as a parameter, if needed.