### PR TITLE
Wire exclude-newer policy into py-rattler solver

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,7 +121,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          repository: conda/conda
+          repository: jezdez/conda
+          ref: feature/repodata-filter-cooldown
           path: conda  # CONDA-RATTLER-SOLVER CHANGE
 
       # CONDA-RATTLER-SOLVER CHANGE
@@ -302,7 +303,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          repository: conda/conda
+          repository: jezdez/conda
+          ref: feature/repodata-filter-cooldown
           path: conda  # CONDA-RATTLER-SOLVER CHANGE
 
       # CONDA-RATTLER-SOLVER CHANGE
@@ -455,7 +457,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          repository: conda/conda
+          repository: jezdez/conda
+          ref: feature/repodata-filter-cooldown
           path: conda  # CONDA-RATTLER-SOLVER CHANGE
 
       # CONDA-RATTLER-SOLVER CHANGE

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ env:
   # we can't break classic from here; no need to test it
   # those tests will still be available for local debugging if necessary
   CONDA_TEST_SOLVERS: rattler
-  CONDA_REF: main
+  CONDA_REF: feature/repodata-filter-cooldown
 
 
 jobs:
@@ -123,7 +123,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          repository: conda/conda
+          repository: jezdez/conda
           path: conda  # CONDA-RATTLER-SOLVER CHANGE
           ref: ${{ env.CONDA_REF }}
 
@@ -315,7 +315,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          repository: conda/conda
+          repository: jezdez/conda
           path: conda  # CONDA-RATTLER-SOLVER CHANGE
           ref: ${{ env.CONDA_REF }}
 
@@ -478,7 +478,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          repository: conda/conda
+          repository: jezdez/conda
           path: conda  # CONDA-RATTLER-SOLVER CHANGE
           ref: ${{ env.CONDA_REF }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ env:
   # we can't break classic from here; no need to test it
   # those tests will still be available for local debugging if necessary
   CONDA_TEST_SOLVERS: rattler
-  CONDA_REF: main
+  CONDA_REF: feature/repodata-filter-cooldown
 
 
 jobs:
@@ -123,7 +123,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          repository: conda/conda
+          repository: jezdez/conda
           path: conda  # CONDA-RATTLER-SOLVER CHANGE
           ref: ${{ env.CONDA_REF }}
 
@@ -305,7 +305,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          repository: conda/conda
+          repository: jezdez/conda
           path: conda  # CONDA-RATTLER-SOLVER CHANGE
           ref: ${{ env.CONDA_REF }}
 
@@ -459,7 +459,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          repository: conda/conda
+          repository: jezdez/conda
           path: conda  # CONDA-RATTLER-SOLVER CHANGE
           ref: ${{ env.CONDA_REF }}
 

--- a/conda_rattler_solver/index.py
+++ b/conda_rattler_solver/index.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import logging
 import os
 import random
@@ -18,7 +17,6 @@ from conda.base.constants import REPODATA_FN
 from conda.base.context import context
 from conda.common.io import DummyExecutor, ThreadLimitedThreadPoolExecutor
 from conda.common.url import path_to_url, remove_auth, split_anaconda_token
-from conda.core.exclude_newer import ExcludeNewerPolicy
 from conda.core.package_cache_data import PackageCacheData
 from conda.core.subdir_data import SubdirData
 from conda.models.channel import Channel
@@ -35,6 +33,7 @@ if TYPE_CHECKING:
     from typing import Self
 
     from conda.common.path import PathsType
+    from conda.core.exclude_newer import ExcludeNewerPolicy
     from conda.gateways.shards import BuildRepodataSubset
     from conda.gateways.shards.typing import Shards
     from conda.models.match_spec import MatchSpec
@@ -81,7 +80,16 @@ class RattlerIndexHelper:
         self._repodata_fn = repodata_fn
         self.in_state = in_state
         self.build_repodata_subset = build_repodata_subset
-        self.exclude_newer_policy = exclude_newer_policy or ExcludeNewerPolicy.disabled()
+        if exclude_newer_policy is None:
+            from conda.core.exclude_newer import ExcludeNewerPolicy
+
+            exclude_newer_policy = ExcludeNewerPolicy.disabled()
+        self.exclude_newer_policy = exclude_newer_policy
+        self._use_python_exclude_newer_filter = self.exclude_newer_policy.active and (
+            self.exclude_newer_policy.global_cutoff is None
+            or self.exclude_newer_policy.has_channel_overrides
+            or self.exclude_newer_policy.has_package_overrides
+        )
 
         self._index: dict[str, _ChannelRepoInfo] = {}
         self._index.update(self._load_channels())
@@ -267,7 +275,9 @@ class RattlerIndexHelper:
             repodata = empty_repodata_dict(subdir, base_url=url)
             for filename, record in shards.iter_records():
                 package_url = f"{url.rstrip('/')}/{filename}"
-                if not self._record_allowed(record, filename, url, package_url):
+                if self._use_python_exclude_newer_filter and not self._record_allowed(
+                    record, filename, url, package_url
+                ):
                     continue
                 if filename.endswith(".tar.bz2"):
                     repodata["packages"][filename] = record
@@ -302,25 +312,13 @@ class RattlerIndexHelper:
             index[info.noauth_url] = info
         return index
 
-    def _uses_python_exclude_newer_filter(self) -> bool:
-        return self.exclude_newer_policy.active and (
-            self.exclude_newer_policy.global_cutoff is None
-            or self.exclude_newer_policy.has_channel_overrides
-            or self.exclude_newer_policy.has_package_overrides
-        )
-
     def _filtered_json_path(self, url: str, json_path: Path) -> Path:
-        if not self._uses_python_exclude_newer_filter():
+        if not self._use_python_exclude_newer_filter:
             return json_path
 
-        repodata = json.loads(json_path.read_text())
-        with NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
-            f.write(json_dump(self._filter_repodata(repodata, url)))
-        filtered_path = Path(f.name)
-        self._unlink_on_del.append(filtered_path)
-        return filtered_path
+        import json
 
-    def _filter_repodata(self, repodata: dict, channel_url: str) -> dict:
+        repodata = json.loads(json_path.read_text())
         filtered = {**repodata}
         for package_group in ("packages", "packages.conda"):
             filtered[package_group] = {
@@ -329,8 +327,8 @@ class RattlerIndexHelper:
                 if self._record_allowed(
                     record,
                     filename,
-                    channel_url,
-                    record.get("url") or f"{channel_url.rstrip('/')}/{filename}",
+                    url,
+                    record.get("url") or f"{url.rstrip('/')}/{filename}",
                 )
             }
 
@@ -342,12 +340,16 @@ class RattlerIndexHelper:
                 if self._record_allowed(
                     record,
                     filename,
-                    channel_url,
-                    record.get("url") or f"{channel_url.rstrip('/')}/{filename}",
+                    url,
+                    record.get("url") or f"{url.rstrip('/')}/{filename}",
                 )
             }
 
-        return filtered
+        with NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+            f.write(json_dump(filtered))
+        filtered_path = Path(f.name)
+        self._unlink_on_del.append(filtered_path)
+        return filtered_path
 
     def _record_allowed(
         self,
@@ -356,9 +358,6 @@ class RattlerIndexHelper:
         channel_url: str,
         package_url: str,
     ) -> bool:
-        if not self._uses_python_exclude_newer_filter():
-            return True
-
         return self.exclude_newer_policy.should_include(
             {
                 **record,

--- a/conda_rattler_solver/index.py
+++ b/conda_rattler_solver/index.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import os
 import random
@@ -17,6 +18,7 @@ from conda.base.constants import REPODATA_FN
 from conda.base.context import context
 from conda.common.io import DummyExecutor, ThreadLimitedThreadPoolExecutor
 from conda.common.url import path_to_url, remove_auth, split_anaconda_token
+from conda.core.exclude_newer import ExcludeNewerPolicy
 from conda.core.package_cache_data import PackageCacheData
 from conda.core.subdir_data import SubdirData
 from conda.models.channel import Channel
@@ -70,6 +72,7 @@ class RattlerIndexHelper:
         pkgs_dirs: PathsType = (),
         in_state: SolverInputState | None = None,
         build_repodata_subset: BuildRepodataSubset | None = None,
+        exclude_newer_policy: ExcludeNewerPolicy | None = None,
     ):
         self._unlink_on_del: list[Path] = []
 
@@ -78,6 +81,7 @@ class RattlerIndexHelper:
         self._repodata_fn = repodata_fn
         self.in_state = in_state
         self.build_repodata_subset = build_repodata_subset
+        self.exclude_newer_policy = exclude_newer_policy or ExcludeNewerPolicy.disabled()
 
         self._index: dict[str, _ChannelRepoInfo] = {}
         self._index.update(self._load_channels())
@@ -172,6 +176,7 @@ class RattlerIndexHelper:
             shutil.copy(json_path, path_copy)
             json_path = path_copy
             self._unlink_on_del.append(path_copy)
+        json_path = self._filtered_json_path(url, json_path)
         # TODO: Support multichannel https://github.com/conda/rattler/issues/1327
         rattler_channel = rattler.Channel(noauth_url_sans_subdir)
         repo = rattler.SparseRepoData(rattler_channel, channel.subdir, json_path)
@@ -261,6 +266,9 @@ class RattlerIndexHelper:
             subdir = Channel.from_url(url).subdir
             repodata = empty_repodata_dict(subdir, base_url=url)
             for filename, record in shards.iter_records():
+                package_url = f"{url.rstrip('/')}/{filename}"
+                if not self._record_allowed(record, filename, url, package_url):
+                    continue
                 if filename.endswith(".tar.bz2"):
                     repodata["packages"][filename] = record
                 elif filename.endswith(".conda"):
@@ -293,6 +301,72 @@ class RattlerIndexHelper:
             info = self._json_path_to_repo_info(url, f.name)
             index[info.noauth_url] = info
         return index
+
+    def _uses_python_exclude_newer_filter(self) -> bool:
+        return self.exclude_newer_policy.active and (
+            self.exclude_newer_policy.global_cutoff is None
+            or self.exclude_newer_policy.has_channel_overrides
+            or self.exclude_newer_policy.has_package_overrides
+        )
+
+    def _filtered_json_path(self, url: str, json_path: Path) -> Path:
+        if not self._uses_python_exclude_newer_filter():
+            return json_path
+
+        repodata = json.loads(json_path.read_text())
+        with NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+            f.write(json_dump(self._filter_repodata(repodata, url)))
+        filtered_path = Path(f.name)
+        self._unlink_on_del.append(filtered_path)
+        return filtered_path
+
+    def _filter_repodata(self, repodata: dict, channel_url: str) -> dict:
+        filtered = {**repodata}
+        for package_group in ("packages", "packages.conda"):
+            filtered[package_group] = {
+                filename: record
+                for filename, record in repodata.get(package_group, {}).items()
+                if self._record_allowed(
+                    record,
+                    filename,
+                    channel_url,
+                    record.get("url") or f"{channel_url.rstrip('/')}/{filename}",
+                )
+            }
+
+        if v3 := repodata.get("v3"):
+            filtered["v3"] = {**v3}
+            filtered["v3"]["whl"] = {
+                filename: record
+                for filename, record in v3.get("whl", {}).items()
+                if self._record_allowed(
+                    record,
+                    filename,
+                    channel_url,
+                    record.get("url") or f"{channel_url.rstrip('/')}/{filename}",
+                )
+            }
+
+        return filtered
+
+    def _record_allowed(
+        self,
+        record: dict,
+        filename: str,
+        channel_url: str,
+        package_url: str,
+    ) -> bool:
+        if not self._uses_python_exclude_newer_filter():
+            return True
+
+        return self.exclude_newer_policy.should_include(
+            {
+                **record,
+                "channel": channel_url,
+                "fn": record.get("fn") or filename,
+                "url": package_url,
+            }
+        )
 
     def _load_channels(self, urls: Iterable[str] | None = None) -> dict[str, _ChannelRepoInfo]:
         if urls is None:

--- a/conda_rattler_solver/index.py
+++ b/conda_rattler_solver/index.py
@@ -219,7 +219,9 @@ class RattlerIndexHelper:
 
         return tuple(dict.fromkeys(urls))  # de-duplicate
 
-    def _get_root_package_from_shard(self, package_names: list[str]) -> dict[str, _ChannelRepoInfo]:
+    def _get_root_package_from_shard(
+        self, package_names: list[str]
+    ) -> dict[str, _ChannelRepoInfo]:
         """
         Builds the repodata subset for a set of packages. Only applicable to sharded channels.
         """
@@ -449,7 +451,9 @@ class RattlerIndexHelper:
                 self._unlink_on_del.append(Path(f.name))
         return repos
 
-    def _search(self, spec: rattler.MatchSpec, index: dict[str, _ChannelRepoInfo]) -> Iterable[PackageRecord]:
+    def _search(
+        self, spec: rattler.MatchSpec, index: dict[str, _ChannelRepoInfo]
+    ) -> Iterable[PackageRecord]:
         """
         Search for packages matching the given spec in the index. This function does not
         build the repodata subset for the requested spec, so it may not find packages
@@ -459,7 +463,9 @@ class RattlerIndexHelper:
             for record in info.repo.load_matching_records([spec]):
                 yield rattler_record_to_conda_record(record)
 
-    def search(self, spec: str | MatchSpec, search_expanded_index: bool = False) -> Iterable[PackageRecord]:
+    def search(
+        self, spec: str | MatchSpec, search_expanded_index: bool = False
+    ) -> Iterable[PackageRecord]:
         """
         Search for packages matching the given spec in the index. For channels that are sharded,
         the requested spec may not be in the loaded index. So, this function will additionally

--- a/conda_rattler_solver/index.py
+++ b/conda_rattler_solver/index.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import os
 import random
@@ -17,6 +18,7 @@ from conda.base.constants import REPODATA_FN
 from conda.base.context import context
 from conda.common.io import DummyExecutor, ThreadLimitedThreadPoolExecutor
 from conda.common.url import path_to_url, remove_auth, split_anaconda_token
+from conda.core.exclude_newer import ExcludeNewerPolicy
 from conda.core.package_cache_data import PackageCacheData
 from conda.core.subdir_data import SubdirData
 from conda.models.channel import Channel
@@ -70,6 +72,7 @@ class RattlerIndexHelper:
         pkgs_dirs: PathsType = (),
         in_state: SolverInputState | None = None,
         build_repodata_subset: BuildRepodataSubset | None = None,
+        exclude_newer_policy: ExcludeNewerPolicy | None = None,
     ):
         self._unlink_on_del: list[Path] = []
 
@@ -78,6 +81,7 @@ class RattlerIndexHelper:
         self._repodata_fn = repodata_fn
         self.in_state = in_state
         self.build_repodata_subset = build_repodata_subset
+        self.exclude_newer_policy = exclude_newer_policy or ExcludeNewerPolicy.disabled()
 
         self._index: dict[str, _ChannelRepoInfo] = {}
         self._index.update(self._load_channels())
@@ -172,6 +176,7 @@ class RattlerIndexHelper:
             shutil.copy(json_path, path_copy)
             json_path = path_copy
             self._unlink_on_del.append(path_copy)
+        json_path = self._filtered_json_path(url, json_path)
         # TODO: Support multichannel https://github.com/conda/rattler/issues/1327
         rattler_channel = rattler.Channel(noauth_url_sans_subdir)
         repo = rattler.SparseRepoData(rattler_channel, channel.subdir, json_path)
@@ -242,6 +247,9 @@ class RattlerIndexHelper:
             subdir = Channel.from_url(url).subdir
             repodata = empty_repodata_dict(subdir, base_url=url)
             for filename, record in shards.iter_records():
+                package_url = f"{url.rstrip('/')}/{filename}"
+                if not self._record_allowed(record, filename, url, package_url):
+                    continue
                 if filename.endswith(".tar.bz2"):
                     repodata["packages"][filename] = record
                 elif filename.endswith(".conda"):
@@ -274,6 +282,72 @@ class RattlerIndexHelper:
             info = self._json_path_to_repo_info(url, f.name)
             index[info.noauth_url] = info
         return index
+
+    def _uses_python_exclude_newer_filter(self) -> bool:
+        return self.exclude_newer_policy.active and (
+            self.exclude_newer_policy.global_cutoff is None
+            or self.exclude_newer_policy.has_channel_overrides
+            or self.exclude_newer_policy.has_package_overrides
+        )
+
+    def _filtered_json_path(self, url: str, json_path: Path) -> Path:
+        if not self._uses_python_exclude_newer_filter():
+            return json_path
+
+        repodata = json.loads(json_path.read_text())
+        with NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+            f.write(json_dump(self._filter_repodata(repodata, url)))
+        filtered_path = Path(f.name)
+        self._unlink_on_del.append(filtered_path)
+        return filtered_path
+
+    def _filter_repodata(self, repodata: dict, channel_url: str) -> dict:
+        filtered = {**repodata}
+        for package_group in ("packages", "packages.conda"):
+            filtered[package_group] = {
+                filename: record
+                for filename, record in repodata.get(package_group, {}).items()
+                if self._record_allowed(
+                    record,
+                    filename,
+                    channel_url,
+                    record.get("url") or f"{channel_url.rstrip('/')}/{filename}",
+                )
+            }
+
+        if v3 := repodata.get("v3"):
+            filtered["v3"] = {**v3}
+            filtered["v3"]["whl"] = {
+                filename: record
+                for filename, record in v3.get("whl", {}).items()
+                if self._record_allowed(
+                    record,
+                    filename,
+                    channel_url,
+                    record.get("url") or f"{channel_url.rstrip('/')}/{filename}",
+                )
+            }
+
+        return filtered
+
+    def _record_allowed(
+        self,
+        record: dict,
+        filename: str,
+        channel_url: str,
+        package_url: str,
+    ) -> bool:
+        if not self._uses_python_exclude_newer_filter():
+            return True
+
+        return self.exclude_newer_policy.should_include(
+            {
+                **record,
+                "channel": channel_url,
+                "fn": record.get("fn") or filename,
+                "url": package_url,
+            }
+        )
 
     def _load_channels(self, urls: Iterable[str] | None = None) -> dict[str, _ChannelRepoInfo]:
         if urls is None:

--- a/conda_rattler_solver/index.py
+++ b/conda_rattler_solver/index.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import logging
 import os
 import random
@@ -18,7 +17,6 @@ from conda.base.constants import REPODATA_FN
 from conda.base.context import context
 from conda.common.io import DummyExecutor, ThreadLimitedThreadPoolExecutor
 from conda.common.url import path_to_url, remove_auth, split_anaconda_token
-from conda.core.exclude_newer import ExcludeNewerPolicy
 from conda.core.package_cache_data import PackageCacheData
 from conda.core.subdir_data import SubdirData
 from conda.models.channel import Channel
@@ -35,6 +33,7 @@ if TYPE_CHECKING:
     from typing import Self
 
     from conda.common.path import PathsType
+    from conda.core.exclude_newer import ExcludeNewerPolicy
     from conda.gateways.shards import BuildRepodataSubset
     from conda.gateways.shards.typing import Shards
     from conda.models.match_spec import MatchSpec
@@ -81,7 +80,16 @@ class RattlerIndexHelper:
         self._repodata_fn = repodata_fn
         self.in_state = in_state
         self.build_repodata_subset = build_repodata_subset
-        self.exclude_newer_policy = exclude_newer_policy or ExcludeNewerPolicy.disabled()
+        if exclude_newer_policy is None:
+            from conda.core.exclude_newer import ExcludeNewerPolicy
+
+            exclude_newer_policy = ExcludeNewerPolicy.disabled()
+        self.exclude_newer_policy = exclude_newer_policy
+        self._use_python_exclude_newer_filter = self.exclude_newer_policy.active and (
+            self.exclude_newer_policy.global_cutoff is None
+            or self.exclude_newer_policy.has_channel_overrides
+            or self.exclude_newer_policy.has_package_overrides
+        )
 
         self._index: dict[str, _ChannelRepoInfo] = {}
         self._index.update(self._load_channels())
@@ -248,7 +256,9 @@ class RattlerIndexHelper:
             repodata = empty_repodata_dict(subdir, base_url=url)
             for filename, record in shards.iter_records():
                 package_url = f"{url.rstrip('/')}/{filename}"
-                if not self._record_allowed(record, filename, url, package_url):
+                if self._use_python_exclude_newer_filter and not self._record_allowed(
+                    record, filename, url, package_url
+                ):
                     continue
                 if filename.endswith(".tar.bz2"):
                     repodata["packages"][filename] = record
@@ -283,25 +293,13 @@ class RattlerIndexHelper:
             index[info.noauth_url] = info
         return index
 
-    def _uses_python_exclude_newer_filter(self) -> bool:
-        return self.exclude_newer_policy.active and (
-            self.exclude_newer_policy.global_cutoff is None
-            or self.exclude_newer_policy.has_channel_overrides
-            or self.exclude_newer_policy.has_package_overrides
-        )
-
     def _filtered_json_path(self, url: str, json_path: Path) -> Path:
-        if not self._uses_python_exclude_newer_filter():
+        if not self._use_python_exclude_newer_filter:
             return json_path
 
-        repodata = json.loads(json_path.read_text())
-        with NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
-            f.write(json_dump(self._filter_repodata(repodata, url)))
-        filtered_path = Path(f.name)
-        self._unlink_on_del.append(filtered_path)
-        return filtered_path
+        import json
 
-    def _filter_repodata(self, repodata: dict, channel_url: str) -> dict:
+        repodata = json.loads(json_path.read_text())
         filtered = {**repodata}
         for package_group in ("packages", "packages.conda"):
             filtered[package_group] = {
@@ -310,8 +308,8 @@ class RattlerIndexHelper:
                 if self._record_allowed(
                     record,
                     filename,
-                    channel_url,
-                    record.get("url") or f"{channel_url.rstrip('/')}/{filename}",
+                    url,
+                    record.get("url") or f"{url.rstrip('/')}/{filename}",
                 )
             }
 
@@ -323,12 +321,16 @@ class RattlerIndexHelper:
                 if self._record_allowed(
                     record,
                     filename,
-                    channel_url,
-                    record.get("url") or f"{channel_url.rstrip('/')}/{filename}",
+                    url,
+                    record.get("url") or f"{url.rstrip('/')}/{filename}",
                 )
             }
 
-        return filtered
+        with NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+            f.write(json_dump(filtered))
+        filtered_path = Path(f.name)
+        self._unlink_on_del.append(filtered_path)
+        return filtered_path
 
     def _record_allowed(
         self,
@@ -337,9 +339,6 @@ class RattlerIndexHelper:
         channel_url: str,
         package_url: str,
     ) -> bool:
-        if not self._uses_python_exclude_newer_filter():
-            return True
-
         return self.exclude_newer_policy.should_include(
             {
                 **record,

--- a/conda_rattler_solver/solver.py
+++ b/conda_rattler_solver/solver.py
@@ -352,8 +352,10 @@ class RattlerSolver(Solver):
                 if context.use_only_tar_bz2
                 else rattler.PackageFormatSelection.PREFER_CONDA_WITH_WHL
             ),
-            "exclude_newer": self._exclude_newer_timedelta(),
         }
+        exclude_newer = self._exclude_newer_timedelta()
+        if exclude_newer is not None:
+            solve_kwargs["exclude_newer"] = exclude_newer
         if log.isEnabledFor(logging.DEBUG):
             dumped = json.dumps(solve_kwargs, indent=2, default=str, sort_keys=True)
             log.debug("Solver input for attempt %s:\n%s", attempt, dumped)

--- a/conda_rattler_solver/solver.py
+++ b/conda_rattler_solver/solver.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 import json
 import logging
 import os
@@ -351,6 +352,7 @@ class RattlerSolver(Solver):
                 if context.use_only_tar_bz2
                 else rattler.PackageFormatSelection.PREFER_CONDA_WITH_WHL
             ),
+            "exclude_newer": self._exclude_newer_timedelta(),
         }
         if log.isEnabledFor(logging.DEBUG):
             dumped = json.dumps(solve_kwargs, indent=2, default=str, sort_keys=True)
@@ -733,6 +735,16 @@ class RattlerSolver(Solver):
             )
             for pkg in in_state.virtual.values()
         ]
+
+    @staticmethod
+    def _exclude_newer_timedelta() -> datetime.timedelta | None:
+        """Convert context.exclude_newer to a timedelta for py-rattler."""
+        value = context.exclude_newer
+        if not value:
+            return None
+        from conda.cli.helpers import parse_duration_to_seconds
+
+        return datetime.timedelta(seconds=parse_duration_to_seconds(value))
 
     def _called_from_conda_build(self) -> bool:
         """

--- a/conda_rattler_solver/solver.py
+++ b/conda_rattler_solver/solver.py
@@ -59,6 +59,8 @@ class RattlerSolver(Solver):
     MAX_SOLVER_ATTEMPTS_CAP = 10
     _uses_ssc = False
     supports_exclude_newer_global = True
+    supports_exclude_newer_channel = True
+    supports_exclude_newer_package = True
 
     @staticmethod
     @cache
@@ -248,6 +250,7 @@ class RattlerSolver(Solver):
             pkgs_dirs=context.pkgs_dirs if context.offline else (),
             in_state=in_state,
             build_repodata_subset=self._build_repodata_subset,
+            exclude_newer_policy=self.exclude_newer_policy,
         )
         for channel in conda_build_channels:
             index.reload_channel(channel)
@@ -758,7 +761,11 @@ class RattlerSolver(Solver):
 
     def _exclude_newer_datetime(self) -> datetime.datetime | None:
         """Return the resolved global cutoff as a UTC datetime for py-rattler."""
-        if self.exclude_newer_policy.global_cutoff is None:
+        if (
+            self.exclude_newer_policy.global_cutoff is None
+            or self.exclude_newer_policy.has_channel_overrides
+            or self.exclude_newer_policy.has_package_overrides
+        ):
             return None
 
         return datetime.datetime.fromtimestamp(

--- a/conda_rattler_solver/solver.py
+++ b/conda_rattler_solver/solver.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 import json
 import logging
 import os
@@ -57,6 +58,7 @@ log = logging.getLogger(f"conda.{__name__}")
 class RattlerSolver(Solver):
     MAX_SOLVER_ATTEMPTS_CAP = 10
     _uses_ssc = False
+    supports_exclude_newer_global = True
 
     @staticmethod
     @cache
@@ -359,6 +361,9 @@ class RattlerSolver(Solver):
                 else rattler.PackageFormatSelection.PREFER_CONDA_WITH_WHL
             ),
         }
+        exclude_newer = self._exclude_newer_datetime()
+        if exclude_newer is not None:
+            solve_kwargs["exclude_newer"] = exclude_newer
         if log.isEnabledFor(logging.DEBUG):
             dumped = json.dumps(solve_kwargs, indent=2, default=str, sort_keys=True)
             log.debug("Solver input for attempt %s:\n%s", attempt, dumped)
@@ -750,6 +755,16 @@ class RattlerSolver(Solver):
             )
             for pkg in in_state.virtual.values()
         ]
+
+    def _exclude_newer_datetime(self) -> datetime.datetime | None:
+        """Return the resolved global cutoff as a UTC datetime for py-rattler."""
+        if self.exclude_newer_policy.global_cutoff is None:
+            return None
+
+        return datetime.datetime.fromtimestamp(
+            self.exclude_newer_policy.global_cutoff,
+            tz=datetime.timezone.utc,
+        )
 
     def _called_from_conda_build(self) -> bool:
         """

--- a/conda_rattler_solver/solver.py
+++ b/conda_rattler_solver/solver.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import datetime
 import json
 import logging
 import os
@@ -39,6 +38,7 @@ from .utils import (
 )
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Iterable, Mapping
     from typing import Literal
 
@@ -767,6 +767,8 @@ class RattlerSolver(Solver):
             or self.exclude_newer_policy.has_package_overrides
         ):
             return None
+
+        import datetime
 
         return datetime.datetime.fromtimestamp(
             self.exclude_newer_policy.global_cutoff,

--- a/conda_rattler_solver/solver.py
+++ b/conda_rattler_solver/solver.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import datetime
 import json
 import logging
 import os
@@ -39,6 +38,7 @@ from .utils import (
 )
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Iterable, Mapping
     from typing import Literal
 
@@ -764,6 +764,8 @@ class RattlerSolver(Solver):
             or self.exclude_newer_policy.has_package_overrides
         ):
             return None
+
+        import datetime
 
         return datetime.datetime.fromtimestamp(
             self.exclude_newer_policy.global_cutoff,

--- a/conda_rattler_solver/solver.py
+++ b/conda_rattler_solver/solver.py
@@ -59,6 +59,8 @@ class RattlerSolver(Solver):
     MAX_SOLVER_ATTEMPTS_CAP = 10
     _uses_ssc = False
     supports_exclude_newer_global = True
+    supports_exclude_newer_channel = True
+    supports_exclude_newer_package = True
 
     @staticmethod
     @cache
@@ -248,6 +250,7 @@ class RattlerSolver(Solver):
             pkgs_dirs=context.pkgs_dirs if context.offline else (),
             in_state=in_state,
             build_repodata_subset=self._build_repodata_subset,
+            exclude_newer_policy=self.exclude_newer_policy,
         )
         for channel in conda_build_channels:
             index.reload_channel(channel)
@@ -755,7 +758,11 @@ class RattlerSolver(Solver):
 
     def _exclude_newer_datetime(self) -> datetime.datetime | None:
         """Return the resolved global cutoff as a UTC datetime for py-rattler."""
-        if self.exclude_newer_policy.global_cutoff is None:
+        if (
+            self.exclude_newer_policy.global_cutoff is None
+            or self.exclude_newer_policy.has_channel_overrides
+            or self.exclude_newer_policy.has_package_overrides
+        ):
             return None
 
         return datetime.datetime.fromtimestamp(

--- a/conda_rattler_solver/solver.py
+++ b/conda_rattler_solver/solver.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 import json
 import logging
 import os
@@ -57,6 +58,7 @@ log = logging.getLogger(f"conda.{__name__}")
 class RattlerSolver(Solver):
     MAX_SOLVER_ATTEMPTS_CAP = 10
     _uses_ssc = False
+    supports_exclude_newer_global = True
 
     @staticmethod
     @cache
@@ -359,6 +361,9 @@ class RattlerSolver(Solver):
                 else rattler.PackageFormatSelection.PREFER_CONDA_WITH_WHL
             ),
         }
+        exclude_newer = self._exclude_newer_datetime()
+        if exclude_newer is not None:
+            solve_kwargs["exclude_newer"] = exclude_newer
         if log.isEnabledFor(logging.DEBUG):
             dumped = json.dumps(solve_kwargs, indent=2, default=str, sort_keys=True)
             log.debug("Solver input for attempt %s:\n%s", attempt, dumped)
@@ -747,6 +752,16 @@ class RattlerSolver(Solver):
             )
             for pkg in in_state.virtual.values()
         ]
+
+    def _exclude_newer_datetime(self) -> datetime.datetime | None:
+        """Return the resolved global cutoff as a UTC datetime for py-rattler."""
+        if self.exclude_newer_policy.global_cutoff is None:
+            return None
+
+        return datetime.datetime.fromtimestamp(
+            self.exclude_newer_policy.global_cutoff,
+            tz=datetime.timezone.utc,
+        )
 
     def _called_from_conda_build(self) -> bool:
         """

--- a/news/49-exclude-newer
+++ b/news/49-exclude-newer
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Support conda's `exclude_newer` policy for global, channel, and package scopes. (#49)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -123,14 +123,18 @@ def test_reload_channels(tmp_path: Path):
 def test_exclude_newer_python_filter_disabled_for_global_only_policy():
     index = object.__new__(RattlerIndexHelper)
     index._unlink_on_del = []
+    index._index = {}
     index.exclude_newer_policy = ExcludeNewerPolicy(global_cutoff=1234.56)
+    index._use_python_exclude_newer_filter = False
 
-    assert not index._uses_python_exclude_newer_filter()
+    path = Path("repodata.json")
+    assert index._filtered_json_path("https://example.test/conda/linux-64", path) == path
 
 
 def test_exclude_newer_record_filter_honors_package_and_channel_overrides():
     index = object.__new__(RattlerIndexHelper)
     index._unlink_on_del = []
+    index._index = {}
     index.exclude_newer_policy = ExcludeNewerPolicy.from_values(
         "1d",
         {"openssl": "false", "numpy": "1d"},
@@ -154,15 +158,17 @@ def test_exclude_newer_record_filter_honors_package_and_channel_overrides():
     assert allowed("scipy", "https://other.example.test/conda/linux-64", NOW - 2 * DAY)
 
 
-def test_exclude_newer_filter_repodata_keeps_unknown_timestamps():
+def test_exclude_newer_filter_repodata_keeps_unknown_timestamps(tmp_path):
     index = object.__new__(RattlerIndexHelper)
     index._unlink_on_del = []
+    index._index = {}
     index.exclude_newer_policy = ExcludeNewerPolicy.from_values(
         "",
         {},
         channel_settings=({"channel": "https://example.test/conda", "exclude_newer": "1d"},),
         now=NOW,
     )
+    index._use_python_exclude_newer_filter = True
     repodata = {
         "packages": {
             "old-1.0-0.tar.bz2": {"name": "old", "timestamp": NOW - 2 * DAY},
@@ -172,7 +178,13 @@ def test_exclude_newer_filter_repodata_keeps_unknown_timestamps():
         "packages.conda": {},
     }
 
-    filtered = index._filter_repodata(repodata, "https://example.test/conda/linux-64")
+    json_path = tmp_path / "repodata.json"
+    json_path.write_text(json.dumps(repodata))
+    filtered_path = index._filtered_json_path(
+        "https://example.test/conda/linux-64",
+        json_path,
+    )
+    filtered = json.loads(filtered_path.read_text())
 
     assert set(filtered["packages"]) == {
         "old-1.0-0.tar.bz2",

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from os import PathLike
 
     from conda.testing.fixtures import HttpTestServerFixture, TmpEnvFixture
+    from pytest_benchmark.fixture import BenchmarkFixture
 
 
 initialize_logging()
@@ -330,13 +331,13 @@ def test_search_sharded_channels_with_requested_packages(
     assert len(results) == 1
     assert results[0].name == "foo"
 
-    results =list(index.search("bar", search_expanded_index=False))
+    results = list(index.search("bar", search_expanded_index=False))
     assert len(results) == 1
     assert results[0].name == "bar"
 
     results = list(index.search("idontexist", search_expanded_index=False))
     assert len(results) == 0
-    
+
     results = list(index.search("idontexist", search_expanded_index=True))
     assert len(results) == 0
 
@@ -365,7 +366,7 @@ def test_search_combo_sharded_channels(tmp_path: Path, http_test_server: HttpTes
     assert len(results) == 1
     assert results[0].name == "foo"
 
-    results = list( index.search("foo", search_expanded_index=False))
+    results = list(index.search("foo", search_expanded_index=False))
     assert len(results) == 0
 
     results = list(index.search("bar", search_expanded_index=True))
@@ -432,8 +433,8 @@ def test_query_search_requested_packages_benchmark(
     Benchmark searching for packages with the context of a package already being requested.
 
     Should observe that searching the index for a package that has been requested as
-    part of the input state should be about the same speed for searching with the `search_expanded_index`
-    set to `True` or `False`.
+    part of the input state should be about the same speed for searching with the
+    `search_expanded_index` set to `True` or `False`.
     """
     url = http_test_server.url
     index = RattlerIndexHelper(

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 from conda.base.context import context, reset_context
+from conda.core.exclude_newer import ExcludeNewerPolicy
 from conda.core.subdir_data import SubdirData
 from conda.gateways.logging import initialize_logging
 from conda.gateways.shards import build_repodata_subset
@@ -27,6 +28,8 @@ if TYPE_CHECKING:
 
 initialize_logging()
 DATA = Path(__file__).parent / "data"
+NOW = 1_700_000_000.0
+DAY = 86400
 
 CONDA_FORGE_WITH_SHARDS = "conda-forge"
 
@@ -115,6 +118,66 @@ def test_reload_channels(tmp_path: Path):
     time.sleep(1)
     index.reload_channel(Channel(str(tmp_path)))
     assert index.n_packages() == initial_count + 1
+
+
+def test_exclude_newer_python_filter_disabled_for_global_only_policy():
+    index = object.__new__(RattlerIndexHelper)
+    index._unlink_on_del = []
+    index.exclude_newer_policy = ExcludeNewerPolicy(global_cutoff=1234.56)
+
+    assert not index._uses_python_exclude_newer_filter()
+
+
+def test_exclude_newer_record_filter_honors_package_and_channel_overrides():
+    index = object.__new__(RattlerIndexHelper)
+    index._unlink_on_del = []
+    index.exclude_newer_policy = ExcludeNewerPolicy.from_values(
+        "1d",
+        {"openssl": "false", "numpy": "1d"},
+        channel_settings=({"channel": "https://example.test/conda", "exclude_newer": "3d"},),
+        now=NOW,
+    )
+
+    def allowed(name: str, channel_url: str, timestamp: float) -> bool:
+        filename = f"{name}-1.0-0.tar.bz2"
+        package_url = f"{channel_url}/{filename}"
+        return index._record_allowed(
+            {"name": name, "timestamp": timestamp},
+            filename,
+            channel_url,
+            package_url,
+        )
+
+    assert allowed("openssl", "https://example.test/conda/linux-64", NOW - 60)
+    assert allowed("numpy", "https://example.test/conda/linux-64", NOW - 2 * DAY)
+    assert not allowed("scipy", "https://example.test/conda/linux-64", NOW - 2 * DAY)
+    assert allowed("scipy", "https://other.example.test/conda/linux-64", NOW - 2 * DAY)
+
+
+def test_exclude_newer_filter_repodata_keeps_unknown_timestamps():
+    index = object.__new__(RattlerIndexHelper)
+    index._unlink_on_del = []
+    index.exclude_newer_policy = ExcludeNewerPolicy.from_values(
+        "",
+        {},
+        channel_settings=({"channel": "https://example.test/conda", "exclude_newer": "1d"},),
+        now=NOW,
+    )
+    repodata = {
+        "packages": {
+            "old-1.0-0.tar.bz2": {"name": "old", "timestamp": NOW - 2 * DAY},
+            "new-1.0-0.tar.bz2": {"name": "new", "timestamp": NOW - 60},
+            "unknown-1.0-0.tar.bz2": {"name": "unknown"},
+        },
+        "packages.conda": {},
+    }
+
+    filtered = index._filter_repodata(repodata, "https://example.test/conda/linux-64")
+
+    assert set(filtered["packages"]) == {
+        "old-1.0-0.tar.bz2",
+        "unknown-1.0-0.tar.bz2",
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 from conda.base.context import context, reset_context
+from conda.core.exclude_newer import ExcludeNewerPolicy
 from conda.core.subdir_data import SubdirData
 from conda.gateways.logging import initialize_logging
 from conda.models.channel import Channel
@@ -26,6 +27,8 @@ if TYPE_CHECKING:
 
 initialize_logging()
 DATA = Path(__file__).parent / "data"
+NOW = 1_700_000_000.0
+DAY = 86400
 
 CONDA_FORGE_WITH_SHARDS = "conda-forge"
 
@@ -116,6 +119,66 @@ def test_reload_channels(tmp_path: Path):
     assert index.n_packages() == initial_count + 1
 
 
+def test_exclude_newer_python_filter_disabled_for_global_only_policy():
+    index = object.__new__(RattlerIndexHelper)
+    index._unlink_on_del = []
+    index.exclude_newer_policy = ExcludeNewerPolicy(global_cutoff=1234.56)
+
+    assert not index._uses_python_exclude_newer_filter()
+
+
+def test_exclude_newer_record_filter_honors_package_and_channel_overrides():
+    index = object.__new__(RattlerIndexHelper)
+    index._unlink_on_del = []
+    index.exclude_newer_policy = ExcludeNewerPolicy.from_values(
+        "1d",
+        {"openssl": "false", "numpy": "1d"},
+        channel_settings=({"channel": "https://example.test/conda", "exclude_newer": "3d"},),
+        now=NOW,
+    )
+
+    def allowed(name: str, channel_url: str, timestamp: float) -> bool:
+        filename = f"{name}-1.0-0.tar.bz2"
+        package_url = f"{channel_url}/{filename}"
+        return index._record_allowed(
+            {"name": name, "timestamp": timestamp},
+            filename,
+            channel_url,
+            package_url,
+        )
+
+    assert allowed("openssl", "https://example.test/conda/linux-64", NOW - 60)
+    assert allowed("numpy", "https://example.test/conda/linux-64", NOW - 2 * DAY)
+    assert not allowed("scipy", "https://example.test/conda/linux-64", NOW - 2 * DAY)
+    assert allowed("scipy", "https://other.example.test/conda/linux-64", NOW - 2 * DAY)
+
+
+def test_exclude_newer_filter_repodata_keeps_unknown_timestamps():
+    index = object.__new__(RattlerIndexHelper)
+    index._unlink_on_del = []
+    index.exclude_newer_policy = ExcludeNewerPolicy.from_values(
+        "",
+        {},
+        channel_settings=({"channel": "https://example.test/conda", "exclude_newer": "1d"},),
+        now=NOW,
+    )
+    repodata = {
+        "packages": {
+            "old-1.0-0.tar.bz2": {"name": "old", "timestamp": NOW - 2 * DAY},
+            "new-1.0-0.tar.bz2": {"name": "new", "timestamp": NOW - 60},
+            "unknown-1.0-0.tar.bz2": {"name": "unknown"},
+        },
+        "packages.conda": {},
+    }
+
+    filtered = index._filter_repodata(repodata, "https://example.test/conda/linux-64")
+
+    assert set(filtered["packages"]) == {
+        "old-1.0-0.tar.bz2",
+        "unknown-1.0-0.tar.bz2",
+    }
+
+
 @pytest.mark.parametrize(
     "load_type,requested",
     [
@@ -147,7 +210,9 @@ def test_load_channel_repo_info_shards(
     if load_type == "shard":
         shards_mod = pytest.importorskip(
             "conda.gateways.shards",
-            reason="conda.gateways.shards not available; install conda 633de45c62, 26.5.0 or later ",
+            reason=(
+                "conda.gateways.shards not available; install conda 633de45c62, 26.5.0 or later"
+            ),
         )
         build_repodata_subset = shards_mod.build_repodata_subset
     else:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -122,14 +122,18 @@ def test_reload_channels(tmp_path: Path):
 def test_exclude_newer_python_filter_disabled_for_global_only_policy():
     index = object.__new__(RattlerIndexHelper)
     index._unlink_on_del = []
+    index._index = {}
     index.exclude_newer_policy = ExcludeNewerPolicy(global_cutoff=1234.56)
+    index._use_python_exclude_newer_filter = False
 
-    assert not index._uses_python_exclude_newer_filter()
+    path = Path("repodata.json")
+    assert index._filtered_json_path("https://example.test/conda/linux-64", path) == path
 
 
 def test_exclude_newer_record_filter_honors_package_and_channel_overrides():
     index = object.__new__(RattlerIndexHelper)
     index._unlink_on_del = []
+    index._index = {}
     index.exclude_newer_policy = ExcludeNewerPolicy.from_values(
         "1d",
         {"openssl": "false", "numpy": "1d"},
@@ -153,15 +157,17 @@ def test_exclude_newer_record_filter_honors_package_and_channel_overrides():
     assert allowed("scipy", "https://other.example.test/conda/linux-64", NOW - 2 * DAY)
 
 
-def test_exclude_newer_filter_repodata_keeps_unknown_timestamps():
+def test_exclude_newer_filter_repodata_keeps_unknown_timestamps(tmp_path):
     index = object.__new__(RattlerIndexHelper)
     index._unlink_on_del = []
+    index._index = {}
     index.exclude_newer_policy = ExcludeNewerPolicy.from_values(
         "",
         {},
         channel_settings=({"channel": "https://example.test/conda", "exclude_newer": "1d"},),
         now=NOW,
     )
+    index._use_python_exclude_newer_filter = True
     repodata = {
         "packages": {
             "old-1.0-0.tar.bz2": {"name": "old", "timestamp": NOW - 2 * DAY},
@@ -171,7 +177,13 @@ def test_exclude_newer_filter_repodata_keeps_unknown_timestamps():
         "packages.conda": {},
     }
 
-    filtered = index._filter_repodata(repodata, "https://example.test/conda/linux-64")
+    json_path = tmp_path / "repodata.json"
+    json_path.write_text(json.dumps(repodata))
+    filtered_path = index._filtered_json_path(
+        "https://example.test/conda/linux-64",
+        json_path,
+    )
+    filtered = json.loads(filtered_path.read_text())
 
     assert set(filtered["packages"]) == {
         "old-1.0-0.tar.bz2",

--- a/tests/test_repoquery.py
+++ b/tests/test_repoquery.py
@@ -21,7 +21,7 @@ def test_repoquery():
     data = json.loads(p.stdout)
     assert data["result"]["status"] == "OK"
     assert len(data["result"]["pkgs"]) > 0
-    assert len([p for p in data["result"]["pkgs"] if p["name"] == "python"]) == 1
+    assert any(pkg["name"] == "python" for pkg in data["result"]["pkgs"])
 
 
 def test_query_search():

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+import datetime
 import json
 import os
 import sys
@@ -15,6 +16,7 @@ from typing import TYPE_CHECKING
 import pytest
 from conda.base.context import context
 from conda.common.compat import on_linux, on_mac, on_win
+from conda.core.exclude_newer import ExcludeNewerPolicy
 from conda.core.prefix_data import PrefixData
 from conda.exceptions import (
     DryRunExit,
@@ -62,6 +64,28 @@ class TestRattlerSolver(SolverTests):
                 "test_unintentional_feature_downgrade",
             ],
         }
+
+
+def test_solver_declares_global_exclude_newer_support_only() -> None:
+    assert Solver.supports_exclude_newer_global is True
+    assert Solver.supports_exclude_newer_package is False
+
+
+def test_exclude_newer_datetime_unset() -> None:
+    solver = object.__new__(Solver)
+    solver.exclude_newer_policy = ExcludeNewerPolicy.disabled()
+
+    assert solver._exclude_newer_datetime() is None
+
+
+def test_exclude_newer_datetime_uses_resolved_global_cutoff() -> None:
+    solver = object.__new__(Solver)
+    solver.exclude_newer_policy = ExcludeNewerPolicy(global_cutoff=1234.56)
+
+    assert solver._exclude_newer_datetime() == datetime.datetime.fromtimestamp(
+        1234.56,
+        tz=datetime.timezone.utc,
+    )
 
 
 def test_python_downgrade_reinstalls_noarch_packages(

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -66,9 +66,10 @@ class TestRattlerSolver(SolverTests):
         }
 
 
-def test_solver_declares_global_exclude_newer_support_only() -> None:
+def test_solver_declares_exclude_newer_support() -> None:
     assert Solver.supports_exclude_newer_global is True
-    assert Solver.supports_exclude_newer_package is False
+    assert Solver.supports_exclude_newer_channel is True
+    assert Solver.supports_exclude_newer_package is True
 
 
 def test_exclude_newer_datetime_unset() -> None:
@@ -86,6 +87,18 @@ def test_exclude_newer_datetime_uses_resolved_global_cutoff() -> None:
         1234.56,
         tz=datetime.timezone.utc,
     )
+
+
+def test_exclude_newer_datetime_disabled_for_policy_overrides() -> None:
+    solver = object.__new__(Solver)
+    solver.exclude_newer_policy = ExcludeNewerPolicy.from_values(
+        "1d",
+        {"openssl": False},
+        channel_settings=({"channel": "https://example.test/conda", "exclude_newer": "3d"},),
+        now=1_700_000_000.0,
+    )
+
+    assert solver._exclude_newer_datetime() is None
 
 
 def test_python_downgrade_reinstalls_noarch_packages(


### PR DESCRIPTION
### Description

Consume conda/conda#15761's resolved `ExcludeNewerPolicy` in the Rattler solver backend.

Conda owns policy parsing and resolves relative cutoffs once per command. This keeps duration and date parsing, date-only semantics, zero-duration behavior, and command-time `now` resolution out of the solver plugin.

### Changes

- Declare support for global, channel, and package `exclude_newer` scopes.
- Pass a global-only cutoff to py-rattler as an absolute UTC `datetime` through `solve_with_sparse_repodata(exclude_newer=...)`.
- Apply conda's policy to repodata in Python when channel or package overrides are active.
- Apply the same Python filtering to sharded repodata.
- Test against `jezdez/conda@feature/repodata-filter-cooldown` until conda/conda#15761 lands.
- Add focused policy, capability, repodata, and sharded-index coverage.
- Add a release note.

Part of conda/conda#15759.

### Checklist - did you ...

- [x] Add a file to the `news` directory for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
