### PR TITLE
fix unexpected python minor bump on conda update python (#100)

### DIFF
--- a/conda_rattler_solver/solver.py
+++ b/conda_rattler_solver/solver.py
@@ -480,12 +480,16 @@ class RattlerSolver(Solver):
             if requested:
                 specs.extend(requested)
                 # https://github.com/conda/conda-rattler-solver/issues/100
-                # Name-only python skips the X.Y.* pin in Block A. When other history
-                # packages bind the current ABI, hold the minor so we do not float to a
-                # newer one (libmamba keeps those installs instead).
+                # Name-only `conda update python` skips the X.Y.* pin in Block A. When
+                # that is the sole request and other history packages bind the ABI, hold
+                # the minor (libmamba keeps those installs instead). Do not apply when
+                # other versioned specs are present (e.g. conda downgrade needing an
+                # older python).
                 if (
                     name == "python"
                     and installed
+                    and in_state.is_updating
+                    and set(in_state.requested) == {"python"}
                     and all(spec.is_name_only_spec for spec in requested)
                     and history_binds_python_abi
                 ):

--- a/conda_rattler_solver/solver.py
+++ b/conda_rattler_solver/solver.py
@@ -428,6 +428,19 @@ class RattlerSolver(Solver):
         if installed_python and to_be_installed_python:
             python_version_might_change = not to_be_installed_python.match(installed_python)
 
+        # Other history packages that depend on python/python_abi effectively hold the
+        # current ABI (libmamba Keep of those installs). Used only for the niche #100 case.
+        history_binds_python_abi = False
+        for hist_name in in_state.history:
+            if hist_name == "python":
+                continue
+            hist_record = in_state.installed.get(hist_name)
+            if not hist_record:
+                continue
+            if any(MatchSpec(dep).name in ("python", "python_abi") for dep in hist_record.depends):
+                history_binds_python_abi = True
+                break
+
         # TODO: Make in_state.requested a dict[str, list[MatchSpec]]
         # This makes tests/core/test_solve.py::test_globstr_matchspec_compatible
         # and test_globstr_matchspec_non_compatible pass
@@ -466,6 +479,18 @@ class RattlerSolver(Solver):
             # Block B: main logic for user requests and installed packages
             if requested:
                 specs.extend(requested)
+                # https://github.com/conda/conda-rattler-solver/issues/100
+                # Name-only python skips the X.Y.* pin in Block A. When other history
+                # packages bind the current ABI, hold the minor so we do not float to a
+                # newer one (libmamba keeps those installs instead).
+                if (
+                    name == "python"
+                    and installed
+                    and all(spec.is_name_only_spec for spec in requested)
+                    and history_binds_python_abi
+                ):
+                    pyver = ".".join(installed.version.split(".")[:2])
+                    constraints.append(f"python {pyver}.*")
             elif name in in_state.always_update:
                 if in_state.update_modifier.UPDATE_ALL and conflicting and not history:
                     # with --update-all, all packages will be requested, but sometimes

--- a/news/100-python-minor-on-name-only-update
+++ b/news/100-python-minor-on-name-only-update
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix `conda update python` jumping to a newer Python minor (e.g. 3.13 → 3.14) when the environment also has packages like `conda` that were explicitly installed. Behavior now matches libmamba: stay on the current major.minor unless the user asks for a different Python version. (#100)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -211,6 +211,49 @@ def test_update_from_latest_not_downgrade(
         assert original_python.version == update_python.version
 
 
+def test_name_only_update_python_keeps_minor_when_history_holds_abi(
+    tmp_env: TmpEnvFixture,
+    conda_cli: CondaCLIFixture,
+) -> None:
+    """
+    https://github.com/conda/conda-rattler-solver/issues/100
+
+    Name-only `conda update python` must not jump minors when another history package
+    that depends on python/python_abi is present. Explicit versioned requests still may.
+    """
+    args = ("--override-channels", "--channel=defaults", "--solver=rattler")
+    with tmp_env("python=3.13", "conda", *args) as prefix:
+        original = PrefixData(prefix).get("python")
+        assert original.version.startswith("3.13.")
+
+        out, err, rc = conda_cli(
+            "update",
+            f"--prefix={prefix}",
+            *args,
+            "--json",
+            "--dry-run",
+            "python",
+        )
+        assert rc == 0
+        data = json.loads(out)
+        if data.get("message") != "All requested packages already installed.":
+            link = {pkg["name"]: pkg for pkg in data.get("actions", {}).get("LINK", ())}
+            if "python" in link:
+                assert link["python"]["version"].startswith("3.13."), link["python"]["version"]
+
+        out, err, rc = conda_cli(
+            "install",
+            f"--prefix={prefix}",
+            *args,
+            "--json",
+            "--dry-run",
+            "python=3.14",
+            raises=DryRunExit,
+        )
+        data = json.loads(out)
+        link = {pkg["name"]: pkg for pkg in data["actions"]["LINK"]}
+        assert link["python"]["version"].startswith("3.14.")
+
 @pytest.mark.skipif(not on_linux, reason="Linux only")
 def test_too_aggressive_update_to_conda_forge_packages(tmp_env: TmpEnvFixture) -> None:
     """


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

- Fixes #100: conda update python no longer jumps Python minors (e.g. 3.13 → 3.14) when the env also has explicitly installed ABI-bound packages such as conda.  This mimics the behavior of libmamba and classic solver.
- Root cause: rattler treated name-only python as update to the highest (Block B in the solver.py) while libmamba effectively holds the stack via Keep on those history installs. The hard python X.Y.* pin was already skipped when python was requested.
- Fix: for sole name-only `conda update python`, if other history packages depend on python/python_abi, add a python X.Y.* constraint. Explicit versioned requests (e.g. python=3.14) and multi-package / non-update commands are unchanged.


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-rattler-solver/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-rattler-solver/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-rattler-solver/blob/main/CONTRIBUTING.md -->
