### PR TITLE
Prevent version downgrades during updates

### DIFF
--- a/conda_rattler_solver/solver.py
+++ b/conda_rattler_solver/solver.py
@@ -466,6 +466,9 @@ class RattlerSolver(Solver):
                 pyver = ".".join(installed.version.split(".")[:2])
                 constraints.append(f"python {pyver}.*")
 
+            if in_state.is_updating and installed and not installed.is_unmanageable:
+                constraints.append(MatchSpec(name=name, version=f">={installed.version}"))
+
             # Block B: main logic for user requests and installed packages
             if requested:
                 specs.extend(requested)

--- a/news/126-prevent-update-downgrades
+++ b/news/126-prevent-update-downgrades
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Prevent updates from selecting package versions older than those already installed. (#126)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -36,6 +36,32 @@ def test_update_all_includes_python_in_always_update(tmp_path):
     assert "numpy" in state.always_update
 
 
+def test_update_all_emits_installed_version_constraint(tmp_path):
+    in_state = SolverInputState(
+        tmp_path,
+        update_modifier=UpdateModifier.UPDATE_ALL,
+        command="update",
+    )
+    in_state.prefix_data._prefix_records["libmamba"] = PrefixRecord(
+        name="libmamba",
+        version="2.3.2",
+        build="0",
+        build_number=0,
+        channel="conda-forge",
+        subdir="noarch",
+        fn="libmamba-2.3.2-0.conda",
+    )
+    out_state = SolverOutputState(solver_input_state=in_state)
+    solver = RattlerSolver(tmp_path, channels=("defaults",), command="update")
+
+    collected = solver._collect_specs_main(in_state, out_state)
+    specs = [str(spec) for spec in collected["specs"]]
+    constraints = [str(spec) for spec in collected["constraints"]]
+
+    assert "libmamba" in specs
+    assert "libmamba >=2.3.2" in constraints
+
+
 def test_update_all_emits_python_constraint_and_update_spec(tmp_path):
     """UPDATE_ALL must request python while constraining to the current major.minor.
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from conda.base.constants import UpdateModifier
+from conda.models.enums import PackageType
 from conda.models.match_spec import MatchSpec
 from conda.models.records import PackageRecord, PrefixRecord
 
@@ -60,6 +61,41 @@ def test_update_all_emits_installed_version_constraint(tmp_path):
 
     assert "libmamba" in specs
     assert "libmamba >=2.3.2" in constraints
+
+
+def test_installed_version_constraint_exclusions(tmp_path):
+    for command, package_type in (
+        ("install", None),
+        ("update", PackageType.VIRTUAL_PYTHON_EGG_UNMANAGEABLE),
+    ):
+        prefix = tmp_path / command
+        in_state = SolverInputState(
+            prefix,
+            requested=("libmamba",),
+            command=command,
+        )
+        in_state.prefix_data._prefix_records["libmamba"] = PrefixRecord(
+            name="libmamba",
+            version="2.3.2",
+            build="0",
+            build_number=0,
+            channel="conda-forge",
+            subdir="noarch",
+            fn="libmamba-2.3.2-0.conda",
+            package_type=package_type,
+        )
+        out_state = SolverOutputState(solver_input_state=in_state)
+        solver = RattlerSolver(
+            prefix,
+            channels=("defaults",),
+            specs_to_add=("libmamba",),
+            command=command,
+        )
+
+        collected = solver._collect_specs_main(in_state, out_state)
+        constraints = [str(spec) for spec in collected["constraints"]]
+
+        assert "libmamba >=2.3.2" not in constraints
 
 
 def test_update_all_emits_python_constraint_and_update_spec(tmp_path):


### PR DESCRIPTION
### Description

Prevent `conda update` from selecting package versions older than those already installed by adding conditional lower-bound constraints for manageable prefix records. This matches the update policy in conda-libmamba-solver without retaining dependencies that can be removed.

These constraints compare versions only. Rattler does not expose an installed-record no-downgrade policy for same-version build changes.

Closes #126.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-rattler-solver/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~